### PR TITLE
Thymeleafの追加とStudentControllerの責務分離のためのリファクタリング

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,26 @@
 ## 概要
-- StudentConverterクラスを追加し、学生データの変換機能を実装しました。
-- remarkフィールドとisDeletedフィールドを追加し、学生情報に対するコメントの管理や削除フラグの実装を行いました。
+Spring BootアプリケーションにThymeleafを導入し、フロントエンドを実装しました。また、既存のStudentControllerとStudentServiceをリファクタリングし、責務の分離とコードの整理を行いました。以下の変更が含まれます。
 
-## 実行結果
-- remarkフィールドに情報を追加 
-![備考欄](https://github.com/user-attachments/assets/35651f63-3f6e-4845-a518-f72128921185)
-![備考欄に優秀な学生追加](https://github.com/user-attachments/assets/84d7885b-c171-41a3-80d3-8900c52f19b2)
-- isDeletedフィールドに情報を追加 
-![論理削除](https://github.com/user-attachments/assets/872d88e6-1e96-460b-8118-ca0e0c5c53e4) 
--  情報が追加されたListの表示
-![studentsCourseList提出](https://github.com/user-attachments/assets/b9901f65-bd5d-4b49-a557-2b7114614792)
+## 変更点
+
+1. Thymeleafの導入
+   - build.gradleにThymeleaf依存関係を追加しました。
+   - 新しいHTMLテンプレート (studentList.html) を追加し、受講生の情報を表示します。
+
+2. StudentControllerのリファクタリング
+   - RestControllerからControllerに変更しました。
+   - Modelを使って、Thymeleafテンプレートにデータを渡すようにしました。
+   - @PatchMappingなどのエンドポイントを削除し、単純化しました。
+
+3. StudentServiceのリファクタリング
+   - 学生とコース情報を結合して返すメソッドを追加しました (getStudentsWithCourses)。
+
+4. StudentRepositoryのメソッド名変更
+   - より明確な命名規則に従い、searchメソッドをsearchStudentに変更しました。
+
+5. HTMLテンプレートの追加
+   - studentList.html: Thymeleafで動的に受講生情報を表示します。
+
+## 動作確認
+- ブラウザから/studentsCourseListエンドポイントにアクセスすることで、受講生の一覧が正しく表示されることを確認しました。
+![スクリーンショット 2024-10-12 123059](https://github.com/user-attachments/assets/d35e0457-5706-403b-8177-fe958ec8235e)

--- a/build.gradle
+++ b/build.gradle
@@ -19,20 +19,19 @@ repositories {
 }
 
 dependencies {
+    //Spring Boot
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    // Thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf:3.3.4'
     //Apache Commons Lang(便利機能、ユーティリティ)
     implementation 'org.apache.commons:commons-lang3:3.14.0'
-
     // Lombok
     compileOnly 'org.projectlombok:lombok:1.18.34'
     annotationProcessor 'org.projectlombok:lombok:1.18.34'
-
     // MySQLドライバ
     runtimeOnly 'com.mysql:mysql-connector-j'
-
     // MyBatis
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
-
     providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
     providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    // バリデーション
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/raisetech/StudentManagementSystem/Application.java
+++ b/src/main/java/raisetech/StudentManagementSystem/Application.java
@@ -8,7 +8,6 @@ import raisetech.StudentManagementSystem.repository.StudentRepository;
 
 public class Application {
 
-
   private StudentRepository repository;
 
   public static void main(String[] args) {

--- a/src/main/java/raisetech/StudentManagementSystem/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagementSystem/controller/StudentController.java
@@ -56,6 +56,6 @@ public class StudentController {
 
     System.out.println(
         studentDetail.getStudent().getName() + "さんが新規受講生として登録されました。");
-    return "redirect:/studentsCoursesList";
+    return "redirect:/studentsCourseList";
   }
 }

--- a/src/main/java/raisetech/StudentManagementSystem/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagementSystem/controller/StudentController.java
@@ -1,11 +1,16 @@
 package raisetech.StudentManagementSystem.controller;
 
+import java.util.Arrays;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 import raisetech.StudentManagementSystem.controller.converter.StudentConverter;
+import raisetech.StudentManagementSystem.data.StudentsCourses;
 import raisetech.StudentManagementSystem.domain.StudentDetail;
 import raisetech.StudentManagementSystem.service.StudentService;
 
@@ -28,5 +33,29 @@ public class StudentController {
     List<StudentDetail> studentDetails = service.getStudentsWithCourses();
     model.addAttribute("studentList", studentDetails);
     return "studentList"; // テンプレート名
+  }
+
+
+  @GetMapping("/newStudent")
+  public String newStudent(Model model) {
+    StudentDetail studentDetail = new StudentDetail(); // StudentDetailのインスタンスを作成
+    studentDetail.setStudentsCourses(Arrays.asList(new StudentsCourses())); // コースの初期化
+    model.addAttribute("studentDetail", studentDetail); // モデルに追加
+    return "registerStudent";
+  }
+
+
+  @PostMapping("/registerStudent")
+  public String registerStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result) {
+    if (result.hasErrors()) {
+      return "registerStudent";
+    }
+
+    // 受講生とコース情報を保存する
+    service.saveStudentDetail(studentDetail);
+
+    System.out.println(
+        studentDetail.getStudent().getName() + "さんが新規受講生として登録されました。");
+    return "redirect:/studentsCoursesList";
   }
 }

--- a/src/main/java/raisetech/StudentManagementSystem/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagementSystem/controller/StudentController.java
@@ -3,19 +3,20 @@ package raisetech.StudentManagementSystem.controller;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import raisetech.StudentManagementSystem.controller.converter.StudentConverter;
 import raisetech.StudentManagementSystem.data.Student;
 import raisetech.StudentManagementSystem.data.StudentsCourses;
 import raisetech.StudentManagementSystem.domain.StudentDetail;
 import raisetech.StudentManagementSystem.service.StudentService;
 
-@RestController
+@Controller
 @RequestMapping("/students")
 public class StudentController {
 
@@ -29,10 +30,19 @@ public class StudentController {
   }
 
   @GetMapping("/studentsCourseList")
-  public List<StudentDetail> getStudentsList() {
+  public String getStudentsList(Model model) {
+    // 受講生とコースのリストを取得
     List<StudentsCourses> studentsCourses = service.searchStudentsCourseList();
     List<Student> students = service.searchStudentList();
-    return studentConverter.convertToStudentDetailList(students, studentsCourses);
+
+    // StudentDetailのリストを取得し、モデルに追加
+    List<StudentDetail> studentDetails = studentConverter.convertToStudentDetailList(students,
+        studentsCourses);
+
+    // StudentDisplayを使用せず、StudentDetailのリストをそのままHTMLに渡す
+    model.addAttribute("studentList", studentDetails); // HTMLテンプレートに渡すリスト
+
+    return "studentList"; // view名 (テンプレート名) を返す。たとえば "studentList.html"
   }
 
   @PatchMapping("/{id}/remark")

--- a/src/main/java/raisetech/StudentManagementSystem/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagementSystem/controller/StudentController.java
@@ -6,20 +6,23 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import raisetech.StudentManagementSystem.controller.converter.StudentConverter;
 import raisetech.StudentManagementSystem.data.StudentsCourses;
 import raisetech.StudentManagementSystem.domain.StudentDetail;
 import raisetech.StudentManagementSystem.service.StudentService;
 
+
 @Controller
+@Validated
 public class StudentController {
 
-  private StudentService service;
-  private StudentConverter converter;
-
+  private final StudentService service;
+  private final StudentConverter converter;
 
   @Autowired
   public StudentController(StudentService service, StudentConverter converter) {
@@ -35,6 +38,12 @@ public class StudentController {
     return "studentList"; // テンプレート名
   }
 
+  @GetMapping("/student/{id}")
+  public String getStudent(@PathVariable int id, Model model) {
+    StudentDetail studentDetail = service.searchStudentById(id);
+    model.addAttribute("studentDetail", studentDetail); // モデルに追加
+    return "updateStudent";
+  }
 
   @GetMapping("/newStudent")
   public String newStudent(Model model) {
@@ -43,7 +52,6 @@ public class StudentController {
     model.addAttribute("studentDetail", studentDetail); // モデルに追加
     return "registerStudent";
   }
-
 
   @PostMapping("/registerStudent")
   public String registerStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result) {
@@ -57,5 +65,26 @@ public class StudentController {
     System.out.println(
         studentDetail.getStudent().getName() + "さんが新規受講生として登録されました。");
     return "redirect:/studentsCourseList";
+  }
+
+  @PostMapping("/updateStudent")
+  public String updateStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result,
+      Model model) {
+    if (result.hasErrors()) {
+      return "updateStudent";
+    }
+
+    try {
+      // 受講生とコース情報を保存する
+      service.updateStudent(studentDetail);
+      System.out.println(
+          studentDetail.getStudent().getName() + "さんの受講生情報が更新されました。");
+    } catch (Exception e) {
+      System.out.println("受講生の更新に失敗しました: " + e.getMessage());
+      model.addAttribute("errorMessage", "受講生の更新に失敗しました。リストページへ戻ります。");
+      return "redirect:/studentsCourseList";
+    }
+
+    return "redirect:/studentsCourseList"; // 成功時のリダイレクト
   }
 }

--- a/src/main/java/raisetech/StudentManagementSystem/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagementSystem/controller/StudentController.java
@@ -2,62 +2,31 @@ package raisetech.StudentManagementSystem.controller;
 
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import raisetech.StudentManagementSystem.controller.converter.StudentConverter;
-import raisetech.StudentManagementSystem.data.Student;
-import raisetech.StudentManagementSystem.data.StudentsCourses;
 import raisetech.StudentManagementSystem.domain.StudentDetail;
 import raisetech.StudentManagementSystem.service.StudentService;
 
 @Controller
-@RequestMapping("/students")
 public class StudentController {
 
-  private final StudentService service;
-  private final StudentConverter studentConverter;
+  private StudentService service;
+  private StudentConverter converter;
+
 
   @Autowired
-  public StudentController(StudentService service, StudentConverter studentConverter) {
+  public StudentController(StudentService service, StudentConverter converter) {
     this.service = service;
-    this.studentConverter = studentConverter;
+    this.converter = converter;
   }
 
+  // 学生とコースの一覧を取得するエンドポイント
   @GetMapping("/studentsCourseList")
-  public String getStudentsList(Model model) {
-    // 受講生とコースのリストを取得
-    List<StudentsCourses> studentsCourses = service.searchStudentsCourseList();
-    List<Student> students = service.searchStudentList();
-
-    // StudentDetailのリストを取得し、モデルに追加
-    List<StudentDetail> studentDetails = studentConverter.convertToStudentDetailList(students,
-        studentsCourses);
-
-    // StudentDisplayを使用せず、StudentDetailのリストをそのままHTMLに渡す
-    model.addAttribute("studentList", studentDetails); // HTMLテンプレートに渡すリスト
-
-    return "studentList"; // view名 (テンプレート名) を返す。たとえば "studentList.html"
-  }
-
-  @PatchMapping("/{id}/remark")
-  public ResponseEntity<String> updateStudentRemark(
-      @PathVariable int id,
-      @RequestBody String newRemark) {
-    service.updateStudentRemark(id, newRemark);
-    return ResponseEntity.ok("学生の備考が更新されました。");
-  }
-
-  @PatchMapping("/{id}/delete")
-  public ResponseEntity<String> updateStudentDeletionStatus(
-      @PathVariable int id,
-      @RequestBody boolean isDeleted) {
-    service.updateStudentIsDeleted(id, isDeleted);
-    return ResponseEntity.ok("受講生情報の削除が成功しました。");
+  public String getStudentsCourseList(Model model) {
+    List<StudentDetail> studentDetails = service.getStudentsWithCourses();
+    model.addAttribute("studentList", studentDetails);
+    return "studentList"; // テンプレート名
   }
 }

--- a/src/main/java/raisetech/StudentManagementSystem/controller/converter/StudentConverter.java
+++ b/src/main/java/raisetech/StudentManagementSystem/controller/converter/StudentConverter.java
@@ -26,7 +26,6 @@ public class StudentConverter {
       StudentDetail studentDetail = new StudentDetail();
       studentDetail.setStudent(student);  // 学生情報をセット
       studentDetail.setStudentsCourses(studentCourseList);  // 学生に関連するコースをセット
-
       // StudentDetail をリストに追加
       studentDetails.add(studentDetail);
     }

--- a/src/main/java/raisetech/StudentManagementSystem/data/Student.java
+++ b/src/main/java/raisetech/StudentManagementSystem/data/Student.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 
 public class Student {
 
-  private int id;
+  private Integer id;
   private String name;
   private String kanaName;
   private String nickname;

--- a/src/main/java/raisetech/StudentManagementSystem/data/Student.java
+++ b/src/main/java/raisetech/StudentManagementSystem/data/Student.java
@@ -1,6 +1,5 @@
 package raisetech.StudentManagementSystem.data;
 
-import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -19,5 +18,4 @@ public class Student {
   private String gender;
   private String remark;
   private boolean isDeleted;
-  private List<StudentsCourses> courses;
 }

--- a/src/main/java/raisetech/StudentManagementSystem/data/Student.java
+++ b/src/main/java/raisetech/StudentManagementSystem/data/Student.java
@@ -1,5 +1,6 @@
 package raisetech.StudentManagementSystem.data;
 
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -18,4 +19,5 @@ public class Student {
   private String gender;
   private String remark;
   private boolean isDeleted;
+  private List<StudentsCourses> courses;
 }

--- a/src/main/java/raisetech/StudentManagementSystem/data/Student.java
+++ b/src/main/java/raisetech/StudentManagementSystem/data/Student.java
@@ -1,11 +1,12 @@
 package raisetech.StudentManagementSystem.data;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-
 public class Student {
 
   private Integer id;
@@ -18,4 +19,12 @@ public class Student {
   private String gender;
   private String remark;
   private boolean isDeleted;
+
+  private List<StudentsCourses> studentsCourses = new ArrayList<>();
+
+  // コース追加メソッド
+  public void addCourse(StudentsCourses course) {
+    course.setStudentId(this.id); // studentIdフィールドを設定
+    this.studentsCourses.add(course);
+  }
 }

--- a/src/main/java/raisetech/StudentManagementSystem/data/StudentsCourses.java
+++ b/src/main/java/raisetech/StudentManagementSystem/data/StudentsCourses.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 public class StudentsCourses {
 
   private Integer id;
-  private Integer studentId;
+  private Integer studentId; // student_idを設定するためのフィールド
   private String courseName;
   private LocalDate startDateAt;
   private LocalDate endDateAt;

--- a/src/main/java/raisetech/StudentManagementSystem/data/StudentsCourses.java
+++ b/src/main/java/raisetech/StudentManagementSystem/data/StudentsCourses.java
@@ -1,6 +1,6 @@
 package raisetech.StudentManagementSystem.data;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,9 +8,9 @@ import lombok.Setter;
 @Setter
 public class StudentsCourses {
 
-  private int id;
-  private int studentId;
+  private Integer id;
+  private Integer studentId;
   private String courseName;
-  private LocalDateTime startDateAt;
-  private LocalDateTime endDateAt;
+  private LocalDate startDateAt;
+  private LocalDate endDateAt;
 }

--- a/src/main/java/raisetech/StudentManagementSystem/data/StudentsCourses.java
+++ b/src/main/java/raisetech/StudentManagementSystem/data/StudentsCourses.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 @Setter
 public class StudentsCourses {
 
-  private String id;
+  private int id;
   private int studentId;
   private String courseName;
   private LocalDateTime startDateAt;

--- a/src/main/java/raisetech/StudentManagementSystem/domain/StudentDetail.java
+++ b/src/main/java/raisetech/StudentManagementSystem/domain/StudentDetail.java
@@ -12,4 +12,5 @@ public class StudentDetail {
 
   private Student student;
   private List<StudentsCourses> studentsCourses;
+  private String startDate;
 }

--- a/src/main/java/raisetech/StudentManagementSystem/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagementSystem/repository/StudentRepository.java
@@ -1,7 +1,9 @@
 package raisetech.StudentManagementSystem.repository;
 
 import java.util.List;
+import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 import raisetech.StudentManagementSystem.data.Student;
@@ -21,4 +23,13 @@ public interface StudentRepository {
 
   @Update("UPDATE students SET name = #{name}, kana_name = #{kanaName}, nickname = #{nickname}, email = #{email}, region = #{region}, age = #{age}, gender = #{gender}, remark = #{remark}, is_deleted = #{isDeleted} WHERE id = #{id}")
   void updateStudent(Student student);
+
+  // 学生を新規登録
+  @Insert("INSERT INTO students (name, kana_name, nickname, email, region, age, gender, remark, is_deleted) VALUES (#{name}, #{kanaName}, #{nickname}, #{email}, #{region}, #{age}, #{gender}, #{remark}, #{isDeleted})")
+  @Options(useGeneratedKeys = true, keyProperty = "id")
+  void save(Student student);
+
+  // コースを新規登録
+  @Insert("INSERT INTO students_courses (student_id, course_name, start_date_at, end_date_at) VALUES (#{studentId}, #{courseName}, #{startDateAt}, #{endDateAt})")
+  void saveCourse(StudentsCourses studentsCourses);
 }

--- a/src/main/java/raisetech/StudentManagementSystem/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagementSystem/repository/StudentRepository.java
@@ -16,20 +16,29 @@ public interface StudentRepository {
   List<Student> searchStudent();
 
   @Select("SELECT * FROM students_courses")
-  List<StudentsCourses> searchStudentsCourses();
+  List<StudentsCourses> searchStudentsCoursesList();
 
   @Select("SELECT * FROM students WHERE id = #{id}")
-  Student findById(int id);
+  Student searchStudentById(int id);
 
-  @Update("UPDATE students SET name = #{name}, kana_name = #{kanaName}, nickname = #{nickname}, email = #{email}, region = #{region}, age = #{age}, gender = #{gender}, remark = #{remark}, is_deleted = #{isDeleted} WHERE id = #{id}")
-  void updateStudent(Student student);
+  @Select("SELECT * FROM students_courses WHERE student_id=#{studentId}")
+  List<StudentsCourses> searchStudentsCourses(int studentId);
 
   // 学生を新規登録
-  @Insert("INSERT INTO students (name, kana_name, nickname, email, region, age, gender, remark, is_deleted) VALUES (#{name}, #{kanaName}, #{nickname}, #{email}, #{region}, #{age}, #{gender}, #{remark}, #{isDeleted})")
+  @Insert("INSERT INTO students (name, kana_name, nickname, email, region, age, gender, remark, is_deleted) VALUES (#{name}, #{kanaName}, #{nickname}, #{email}, #{region}, #{age}, #{gender}, #{remark}, 0)")
   @Options(useGeneratedKeys = true, keyProperty = "id")
   void saveStudent(Student student);
 
   // コースを新規登録
   @Insert("INSERT INTO students_courses (student_id, course_name, start_date_at, end_date_at) VALUES (#{studentId}, #{courseName}, #{startDateAt}, #{endDateAt})")
   void saveCourse(StudentsCourses studentsCourses);
+
+  // 学生情報を更新
+  @Update("UPDATE students SET name=#{name}, kana_name=#{kanaName}, nickname=#{nickname}, email=#{email}, region=#{region}, age=#{age}, gender=#{gender}, remark=#{remark} WHERE id=#{id}")
+  void updateStudent(Student student);
+
+  // コースを更新
+  @Update("UPDATE students_courses SET course_name=#{courseName}, start_date_at=#{startDateAt}, end_date_at=#{endDateAt} WHERE id=#{id}")
+  void updateCourse(StudentsCourses studentsCourses);
+
 }

--- a/src/main/java/raisetech/StudentManagementSystem/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagementSystem/repository/StudentRepository.java
@@ -10,19 +10,15 @@ import raisetech.StudentManagementSystem.data.StudentsCourses;
 @Mapper
 public interface StudentRepository {
 
-  // 全ての学生情報を取得する
   @Select("SELECT * FROM students")
-  List<Student> search();
+  List<Student> searchStudent();
 
-  // コースを全件取得する
   @Select("SELECT * FROM students_courses")
   List<StudentsCourses> searchStudentsCourses();
 
-  // 学生情報をIDで取得する
   @Select("SELECT * FROM students WHERE id = #{id}")
   Student findById(int id);
 
-  // 学生情報を更新する
   @Update("UPDATE students SET name = #{name}, kana_name = #{kanaName}, nickname = #{nickname}, email = #{email}, region = #{region}, age = #{age}, gender = #{gender}, remark = #{remark}, is_deleted = #{isDeleted} WHERE id = #{id}")
   void updateStudent(Student student);
 }

--- a/src/main/java/raisetech/StudentManagementSystem/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagementSystem/repository/StudentRepository.java
@@ -27,7 +27,7 @@ public interface StudentRepository {
   // 学生を新規登録
   @Insert("INSERT INTO students (name, kana_name, nickname, email, region, age, gender, remark, is_deleted) VALUES (#{name}, #{kanaName}, #{nickname}, #{email}, #{region}, #{age}, #{gender}, #{remark}, #{isDeleted})")
   @Options(useGeneratedKeys = true, keyProperty = "id")
-  void save(Student student);
+  void saveStudent(Student student);
 
   // コースを新規登録
   @Insert("INSERT INTO students_courses (student_id, course_name, start_date_at, end_date_at) VALUES (#{studentId}, #{courseName}, #{startDateAt}, #{endDateAt})")

--- a/src/main/java/raisetech/StudentManagementSystem/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagementSystem/service/StudentService.java
@@ -63,11 +63,11 @@ public class StudentService {
     // 学生情報を保存し、生成されたIDを取得
     studentRepository.saveStudent(studentDetail.getStudent());
 
-    // 保存した学生IDを使ってコース情報を保存
+    // 学生IDが生成された後に各コースにIDを設定
     for (StudentsCourses course : studentDetail.getStudentsCourses()) {
-      // student.getId()がnullでないか確認
       if (studentDetail.getStudent().getId() != null) {
-        course.setStudentId(studentDetail.getStudent().getId()); // 新しく作成した学生IDをコースにセット
+        // addCourseメソッドを使って自動的にstudentIdを設定
+        studentDetail.getStudent().addCourse(course);
         studentRepository.saveCourse(course);
       } else {
         throw new RuntimeException("Student ID is null. The course cannot be saved.");
@@ -81,6 +81,9 @@ public class StudentService {
     studentRepository.updateStudent(studentDetail.getStudent());
 
     for (StudentsCourses course : studentDetail.getStudentsCourses()) {
+      // addCourseメソッドを使用して、studentIdを設定
+      studentDetail.getStudent().addCourse(course);
+
       if (course.getId() == null) {
         studentRepository.saveCourse(course);  // 新規コースを挿入
       } else {
@@ -88,4 +91,5 @@ public class StudentService {
       }
     }
   }
+
 }

--- a/src/main/java/raisetech/StudentManagementSystem/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagementSystem/service/StudentService.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import raisetech.StudentManagementSystem.data.Student;
 import raisetech.StudentManagementSystem.data.StudentsCourses;
 import raisetech.StudentManagementSystem.domain.StudentDetail;
@@ -45,20 +44,5 @@ public class StudentService {
     }
 
     return new ArrayList<>(studentDetailMap.values());
-  }
-
-  // 学生の備考を更新するメソッド
-  @Transactional
-  public void updateStudentRemark(int id, String newRemark) {
-    // 学生を取得
-    Student student = studentRepository.findById(id);
-    if (student != null) {
-      // 備考を更新
-      student.setRemark(newRemark);
-      // データベースを更新
-      studentRepository.updateStudent(student);
-    } else {
-      throw new RuntimeException("学生が見つかりません: ID = " + id);
-    }
   }
 }

--- a/src/main/java/raisetech/StudentManagementSystem/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagementSystem/service/StudentService.java
@@ -42,7 +42,18 @@ public class StudentService {
         studentDetail.getStudentsCourses().add(course);
       }
     }
-
     return new ArrayList<>(studentDetailMap.values());
   }
+
+  public void saveStudentDetail(StudentDetail studentDetail) {
+    // まず、学生情報を保存
+    studentRepository.save(studentDetail.getStudent());
+
+    // 保存した学生IDを使ってコース情報を保存
+    for (StudentsCourses course : studentDetail.getStudentsCourses()) {
+      course.setStudentId(studentDetail.getStudent().getId()); // 新しく作成した学生IDをコースにセット
+      studentRepository.saveCourse(course);
+    }
+  }
+
 }

--- a/src/main/java/raisetech/StudentManagementSystem/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagementSystem/service/StudentService.java
@@ -47,7 +47,7 @@ public class StudentService {
 
   public void saveStudentDetail(StudentDetail studentDetail) {
     // まず、学生情報を保存
-    studentRepository.save(studentDetail.getStudent());
+    studentRepository.saveStudent(studentDetail.getStudent());
 
     // 保存した学生IDを使ってコース情報を保存
     for (StudentsCourses course : studentDetail.getStudentsCourses()) {

--- a/src/main/resources/templates/registerStudent.html
+++ b/src/main/resources/templates/registerStudent.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>受講生登録</title>
+</head>
+<body>
+<h1>受講生登録</h1>
+<form th:action="@{/registerStudent}" th:object="${studentDetail}" method="post">
+  <div>
+    <label for="name">名前</label>
+    <input type="text" id="name" th:field="*{student.name}" required/>
+  </div>
+  <div>
+    <label for="kanaName">かな</label>
+    <input type="text" id="kanaName" th:field="*{student.kanaName}"/>
+  </div>
+  <div>
+    <label for="nickname">コミュニティ登録名</label>
+    <input type="text" id="nickname" th:field="*{student.nickname}"/>
+  </div>
+  <div>
+    <label for="age">年齢</label>
+    <input type="text" id="age" th:field="*{student.age}"/>
+  </div>
+  <div>
+    <label for="gender">性別</label>
+    <select id="gender" th:field="*{student.gender}" required>
+      <option value="" disabled selected>選択してください</option>
+      <option value="男">男</option>
+      <option value="女">女</option>
+      <option value="その他">その他</option>
+    </select>
+  </div>
+  <div>
+    <label for="email">メールアドレス</label>
+    <input type="email" id="email" th:field="*{student.email}" required/>
+  </div>
+  <div>
+    <label for="region">住所</label>
+    <input type="text" id="region" th:field="*{student.region}" required/>
+  </div>
+  <div>
+    <label for="remark">備考</label>
+    <input type="text" id="remark" th:field="*{student.remark}"/>
+  </div>
+
+  <!-- courses section -->
+  <h2>コース情報</h2>
+  <div>
+    <label for="courseName">コース名</label>
+    <select id="courseName" th:field="*{studentsCourses[0].courseName}" required>
+      <option value="" disabled selected>選択してください</option>
+      <option value="AWS">AWS</option>
+      <option value="Java">Java</option>
+      <option value="WordPress">WordPress</option>
+      <option value="デザイン">デザイン</option>
+      <option value="マーケティング">マーケティング</option>
+    </select>
+  </div>
+  <div>
+    <label for="startDateAt">開始日</label>
+    <input type="datetime-local" id="startDateAt" th:field="*{studentsCourses[0].startDateAt}"
+           required/>
+  </div>
+  <div>
+    <label for="endDateAt">終了日</label>
+    <input type="datetime-local" id="endDateAt" th:field="*{studentsCourses[0].endDateAt}"/>
+  </div>
+
+  <div>
+    <button type="submit">登録</button>
+  </div>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>受講生一覧</title>
+</head>
+<body>
+<h1>受講生一覧</h1>
+<table border="1">
+  <thead>
+  <tr>
+    <th>ID</th>
+    <th>名前</th>
+    <th>カナ名</th>
+    <th>ニックネーム</th>
+    <th>メールアドレス</th>
+    <th>地域</th>
+    <th>性別</th>
+    <th>備考</th>
+    <th>コース</th> <!-- コースの表示用列を追加 -->
+  </tr>
+  </thead>
+  <tbody>
+  <tr th:each="studentDetail : ${studentList}">
+    <td th:text="${studentDetail.student.id}">2</td>
+    <td th:text="${studentDetail.student.name}">大谷翔平</td>
+    <td th:text="${studentDetail.student.kanaName}">おおたに しょうへい</td>
+    <td th:text="${studentDetail.student.nickname}">Sho</td>
+    <td th:text="${studentDetail.student.email}">shohei.otani@example.com</td>
+    <td th:text="${studentDetail.student.region}">アメリカ</td>
+    <td th:text="${studentDetail.student.gender}">男</td>
+    <td th:text="${studentDetail.student.remark}">学生</td>
+    <td th:text="${studentDetail.student.courses}">コース1, コース2</td>
+  </tr>
+  </tbody>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -35,8 +35,9 @@
     <td th:text="${studentDetail.student.remark}">NULL</td>
     <td>
       <ul>
-        <li th:each="course : ${studentDetail.studentsCourses}" th:text="${course.courseName}">
-          Java
+        <li th:each="course : ${studentDetail.studentsCourses}">
+          <span th:text="${course.courseName}"></span> - <span
+            th:text="${course.startDateAt}"></span>
         </li>
       </ul>
     </td>

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -25,15 +25,15 @@
     <td th:text="${studentDetail.student.id}">1</td>
     <td th:text="${studentDetail.student.name}">室伏広治</td>
     <td th:text="${studentDetail.student.kanaName}">むろふし こうじ</td>
-    <td th:text="${studentDetail.student.nickname}">Sho</td>
-    <td th:text="${studentDetail.student.email}">shohei.otani@example.com</td>
-    <td th:text="${studentDetail.student.region}">アメリカ</td>
+    <td th:text="${studentDetail.student.nickname}">Koji</td>
+    <td th:text="${studentDetail.student.email}">koji.murobushi@example.com</td>
+    <td th:text="${studentDetail.student.region}">日本</td>
     <td th:text="${studentDetail.student.gender}">男</td>
-    <td th:text="${studentDetail.student.remark}">学生</td>
+    <td th:text="${studentDetail.student.remark}">NULL</td>
     <td>
       <ul>
         <li th:each="course : ${studentDetail.studentsCourses}" th:text="${course.courseName}">
-          AWS
+          Java
         </li>
       </ul>
     </td>

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -17,20 +17,26 @@
     <th>地域</th>
     <th>性別</th>
     <th>備考</th>
-    <th>コース</th> <!-- コースの表示用列を追加 -->
+    <th>コース</th>
   </tr>
   </thead>
   <tbody>
   <tr th:each="studentDetail : ${studentList}">
-    <td th:text="${studentDetail.student.id}">2</td>
-    <td th:text="${studentDetail.student.name}">大谷翔平</td>
-    <td th:text="${studentDetail.student.kanaName}">おおたに しょうへい</td>
+    <td th:text="${studentDetail.student.id}">1</td>
+    <td th:text="${studentDetail.student.name}">室伏広治</td>
+    <td th:text="${studentDetail.student.kanaName}">むろふし こうじ</td>
     <td th:text="${studentDetail.student.nickname}">Sho</td>
     <td th:text="${studentDetail.student.email}">shohei.otani@example.com</td>
     <td th:text="${studentDetail.student.region}">アメリカ</td>
     <td th:text="${studentDetail.student.gender}">男</td>
     <td th:text="${studentDetail.student.remark}">学生</td>
-    <td th:text="${studentDetail.student.courses}">コース1, コース2</td>
+    <td>
+      <ul>
+        <li th:each="course : ${studentDetail.studentsCourses}" th:text="${course.courseName}">
+          AWS
+        </li>
+      </ul>
+    </td>
   </tr>
   </tbody>
 </table>

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -23,7 +23,10 @@
   <tbody>
   <tr th:each="studentDetail : ${studentList}">
     <td th:text="${studentDetail.student.id}">1</td>
-    <td th:text="${studentDetail.student.name}">室伏広治</td>
+    <td>
+      <a href="/studentList" th:href="@{/student/{id}(id=${studentDetail.student.id})}"
+         th:text="${studentDetail.student.name}">室伏広治</a>
+    </td>
     <td th:text="${studentDetail.student.kanaName}">むろふし こうじ</td>
     <td th:text="${studentDetail.student.nickname}">Koji</td>
     <td th:text="${studentDetail.student.email}">koji.murobushi@example.com</td>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -1,7 +1,38 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 <head>
+  <meta charset="UTF-8">
   <title>受講生詳細</title>
+  <script>
+    function addCourse() {
+      const coursesContainer = document.getElementById('coursesContainer');
+      const courseIndex = coursesContainer.children.length; // 現在のコース数を取得
+      const newCourseDiv = document.createElement('div');
+
+      newCourseDiv.innerHTML = `
+        <label for="studentCourse__${courseIndex}__id">受講コースID: </label>
+        <input type="text" id="studentCourse__${courseIndex}__id" name="studentsCourses[${courseIndex}].id" readonly/>
+
+        <label for="courseName__${courseIndex}">コース名</label>
+        <select id="courseName__${courseIndex}" name="studentsCourses[${courseIndex}].courseName" required>
+          <option value="" disabled selected>選択してください</option>
+          <option value="AWS">AWS</option>
+          <option value="Java">Java</option>
+          <option value="WordPress">WordPress</option>
+          <option value="デザイン">デザイン</option>
+          <option value="マーケティング">マーケティング</option>
+        </select>
+
+        <label for="startDateAt__${courseIndex}">開始日</label>
+        <input type="date" id="startDateAt__${courseIndex}" name="studentsCourses[${courseIndex}].startDateAt" required/>
+
+        <label for="endDateAt__${courseIndex}">終了日</label>
+        <input type="date" id="endDateAt__${courseIndex}" name="studentsCourses[${courseIndex}].endDateAt"/>
+      `;
+
+      coursesContainer.appendChild(newCourseDiv);
+    }
+  </script>
 </head>
 <body>
 <h1>受講生詳細</h1>
@@ -49,31 +80,35 @@
   </div>
 
   <h2>コース情報</h2>
-  <div th:each="course, stat : *{studentsCourses}">
-    <!-- 受講コースID -->
-    <label for="id" th:for="studentCourse__${stat.index}__id">受講コースID: </label>
-    <input type="text" id="id" th:id="studentCourse__${stat.index}__id"
-           th:field="*{studentsCourses[__${stat.index}__].id}" readonly/>
+  <div id="coursesContainer">
+    <div th:each="course, stat : *{studentsCourses}">
+      <label for="studentCourse__${stat.index}__id">受講コースID: </label>
+      <input type="text" id="studentCourse__${stat.index}__id"
+             th:field="*{studentsCourses[__${stat.index}__].id}" readonly/>
 
-    <label for="courseName">コース名</label>
-    <select id="courseName" th:field="*{studentsCourses[__${stat.index}__].courseName}" required>
-      <option value="" disabled selected>選択してください</option>
-      <option value="AWS">AWS</option>
-      <option value="Java">Java</option>
-      <option value="WordPress">WordPress</option>
-      <option value="デザイン">デザイン</option>
-      <option value="マーケティング">マーケティング</option>
-    </select>
+      <label for="courseName__${stat.index}">コース名</label>
+      <select id="courseName__${stat.index}"
+              th:field="*{studentsCourses[__${stat.index}__].courseName}" required>
+        <option value="" disabled selected>選択してください</option>
+        <option value="AWS">AWS</option>
+        <option value="Java">Java</option>
+        <option value="WordPress">WordPress</option>
+        <option value="デザイン">デザイン</option>
+        <option value="マーケティング">マーケティング</option>
+      </select>
 
-    <!-- 開始日 -->
-    <label for="startDateAt">開始日</label>
-    <input type="date" id="startDateAt" th:field="*{studentsCourses[__${stat.index}__].startDateAt}"
-           required/>
+      <label for="startDateAt__${stat.index}">開始日</label>
+      <input type="date" id="startDateAt__${stat.index}"
+             th:field="*{studentsCourses[__${stat.index}__].startDateAt}" required/>
 
-    <!-- 終了日 -->
-    <label for="endDateAt">終了日</label>
-    <input type="date" id="endDateAt" th:field="*{studentsCourses[__${stat.index}__].endDateAt}"/>
+      <label for="endDateAt__${stat.index}">終了日</label>
+      <input type="date" id="endDateAt__${stat.index}"
+             th:field="*{studentsCourses[__${stat.index}__].endDateAt}"/>
+    </div>
+  </div>
 
+  <div>
+    <button type="button" onclick="addCourse()">コース追加</button>
   </div>
 
   <div>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -1,16 +1,18 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>受講生登録</title>
+  <title>受講生詳細</title>
 </head>
 <body>
-<h1>受講生登録</h1>
-<form th:action="@{/registerStudent}" th:object="${studentDetail}" method="post">
+<h1>受講生詳細</h1>
+<form th:action="@{/updateStudent}" th:object="${studentDetail}" method="post">
+  <div>
+    <label for="id">ID</label>
+    <input type="text" id="id" th:field="*{student.id}" required/>
+  </div>
   <div>
     <label for="name">名前</label>
     <input type="text" id="name" th:field="*{student.name}" required/>
-    <div th:if="${#fields.hasErrors('student.name')}" th:errors="*{student.name}"
-         style="color: red;"></div>
   </div>
   <div>
     <label for="kanaName">かな</label>
@@ -46,11 +48,15 @@
     <input type="text" id="remark" th:field="*{student.remark}"/>
   </div>
 
-  <!-- courses section -->
   <h2>コース情報</h2>
-  <div>
+  <div th:each="course, stat : *{studentsCourses}">
+    <!-- 受講コースID -->
+    <label for="id" th:for="studentCourse__${stat.index}__id">受講コースID: </label>
+    <input type="text" id="id" th:id="studentCourse__${stat.index}__id"
+           th:field="*{studentsCourses[__${stat.index}__].id}" readonly/>
+
     <label for="courseName">コース名</label>
-    <select id="courseName" th:field="*{studentsCourses[0].courseName}" required>
+    <select id="courseName" th:field="*{studentsCourses[__${stat.index}__].courseName}" required>
       <option value="" disabled selected>選択してください</option>
       <option value="AWS">AWS</option>
       <option value="Java">Java</option>
@@ -58,20 +64,22 @@
       <option value="デザイン">デザイン</option>
       <option value="マーケティング">マーケティング</option>
     </select>
-  </div>
-  <div>
+
+    <!-- 開始日 -->
     <label for="startDateAt">開始日</label>
-    <input type="date" id="startDateAt" th:field="*{studentsCourses[0].startDateAt}"
+    <input type="date" id="startDateAt" th:field="*{studentsCourses[__${stat.index}__].startDateAt}"
            required/>
-  </div>
-  <div>
+
+    <!-- 終了日 -->
     <label for="endDateAt">終了日</label>
-    <input type="date" id="endDateAt" th:field="*{studentsCourses[0].endDateAt}"/>
+    <input type="date" id="endDateAt" th:field="*{studentsCourses[__${stat.index}__].endDateAt}"/>
+
   </div>
 
   <div>
-    <button type="submit">登録</button>
+    <button type="submit">更新</button>
   </div>
+
 </form>
 </body>
 </html>


### PR DESCRIPTION
## 概要
Spring BootアプリケーションにThymeleafを導入し、フロントエンドを実装しました。また、既存のStudentControllerとStudentServiceをリファクタリングし、責務の分離とコードの整理を行いました。以下の変更が含まれます。

## 変更点

1. Thymeleafの導入
   - build.gradleにThymeleaf依存関係を追加しました。
   - 新しいHTMLテンプレート (studentList.html) を追加し、受講生の情報を表示します。

2. StudentControllerのリファクタリング
   - RestControllerからControllerに変更しました。
   - Modelを使って、Thymeleafテンプレートにデータを渡すようにしました。
   - @PatchMappingなどのエンドポイントを削除し、単純化しました。

3. StudentServiceのリファクタリング
   - 学生とコース情報を結合して返すメソッドを追加しました (getStudentsWithCourses)。

4. StudentRepositoryのメソッド名変更
   - より明確な命名規則に従い、searchメソッドをsearchStudentに変更しました。

5. HTMLテンプレートの追加
   - studentList.html: Thymeleafで動的に受講生情報を表示します。

## 動作確認
- ブラウザから/studentsCourseListエンドポイントにアクセスすることで、受講生の一覧が正しく表示されることを確認しました。
![スクリーンショット 2024-10-12 123059](https://github.com/user-attachments/assets/d35e0457-5706-403b-8177-fe958ec8235e)