### PR TITLE
レスポンスJSON変換

### DIFF
--- a/src/main/java/raisetech/StudentManagementSystem/controller/handler/GlobalExceptionHandler.java
+++ b/src/main/java/raisetech/StudentManagementSystem/controller/handler/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package raisetech.StudentManagementSystem.controller.handler;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -12,25 +14,38 @@ import raisetech.StudentManagementSystem.exception.CustomAppException;
 public class GlobalExceptionHandler {
 
   @ExceptionHandler(CustomAppException.class)
-  public ResponseEntity<String> handleCustomAppException(CustomAppException ex) {
+  public ResponseEntity<Map<String, String>> handleCustomAppException(CustomAppException ex) {
+    Map<String, String> errorResponse = new LinkedHashMap<>();
+    errorResponse.put("error", "エラーメッセージ");
+    errorResponse.put("message", ex.getMessage());
+
     return ResponseEntity.status(HttpStatus.NOT_FOUND)
-        .body("エラーメッセージ：\n" + ex.getMessage());
+        .body(errorResponse);
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<String> handleValidationExceptions(MethodArgumentNotValidException ex) {
-    StringBuilder errors = new StringBuilder();
+  public ResponseEntity<Map<String, Object>> handleValidationExceptions(
+      MethodArgumentNotValidException ex) {
+    Map<String, Object> errorResponse = new LinkedHashMap<>();
+    errorResponse.put("error", "バリデーションエラー");
+
+    Map<String, String> fieldErrors = new LinkedHashMap<>();
     for (FieldError error : ex.getBindingResult().getFieldErrors()) {
-      errors.append("エラーメッセージ: ")
-          .append(error.getDefaultMessage())
-          .append("\n");
+      fieldErrors.put(error.getField(), error.getDefaultMessage());
     }
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors.toString());
+    errorResponse.put("fieldErrors", fieldErrors);
+
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(errorResponse);
   }
 
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<String> handleGeneralException(Exception ex) {
+  public ResponseEntity<Map<String, String>> handleGeneralException(Exception ex) {
+    Map<String, String> errorResponse = new LinkedHashMap<>();
+    errorResponse.put("error", "予期しないエラー");
+    errorResponse.put("message", ex.getMessage());
+
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-        .body("エラーメッセージ：\n" + ex.getMessage());
+        .body(errorResponse);
   }
 }


### PR DESCRIPTION
# 変更点まとめ
## 1. handleCustomAppException のレスポンスを JSON に変更
- ResponseEntity<String> → ResponseEntity<Map<String, String>> に変更
- HashMap の代わりに LinkedHashMap を使用
- JSON レスポンスの形式に統一（error と message を含める）

## 2. handleValidationExceptions のレスポンスを JSON に変更
- ResponseEntity<String> → ResponseEntity<Map<String, Object>> に変更
- バリデーションエラーを fieldErrors として JSON に整理
- StringBuilder でエラーメッセージを作成していたのを Map<String, String> に変更
- LinkedHashMap を使用して JSON の順序を維持

## 3. handleGeneralException のレスポンスを JSON に変更
- ResponseEntity<String> → ResponseEntity<Map<String, String>> に変更
- LinkedHashMap を使用
- JSON レスポンスの形式に統一（error と message を含める）

## 4. import 文の追加
- LinkedHashMap と Map のインポートを追加

## 動作確認
- CustomAppException 発生時
  - 例外が発生するシナリオ（例: 存在しない学生IDで取得リクエスト）で、HTTPステータス404とともに以下のJSONレスポンスが返されるか確認しました。
![error404](https://github.com/user-attachments/assets/d93c9da9-469d-458f-b680-bb3c0a7508cf)

- バリデーションエラー (MethodArgumentNotValidException)
  - 不正なデータ（例: 必須フィールドの欠如、無効な値）を含むリクエストを送信し、HTTPステータス400とともに以下のJSONレスポンスが返されるか確認しました。
![error400](https://github.com/user-attachments/assets/91ef0533-0789-40ee-af96-c3febbf1b87c)

- 一般的な例外 (Exception)
  - 予期しないエラーが発生する状況で、HTTPステータス500とともに以下のJSONレスポンスが返されるか確認しました。
![error500](https://github.com/user-attachments/assets/b0deb497-8e4d-4775-8bf1-13659a5b60be)
