### PR TITLE
Converterのテストクラスの追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ dependencies {
 
     providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/raisetech/StudentManagementSystem/controller/handler/GlobalExceptionHandler.java
+++ b/src/main/java/raisetech/StudentManagementSystem/controller/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package raisetech.StudentManagementSystem.controller.handler;
 
+import jakarta.validation.ConstraintViolationException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
@@ -18,7 +19,6 @@ public class GlobalExceptionHandler {
     Map<String, String> errorResponse = new LinkedHashMap<>();
     errorResponse.put("error", "エラーメッセージ");
     errorResponse.put("message", ex.getMessage());
-
     return ResponseEntity.status(HttpStatus.NOT_FOUND)
         .body(errorResponse);
   }
@@ -28,13 +28,25 @@ public class GlobalExceptionHandler {
       MethodArgumentNotValidException ex) {
     Map<String, Object> errorResponse = new LinkedHashMap<>();
     errorResponse.put("error", "バリデーションエラー");
-
     Map<String, String> fieldErrors = new LinkedHashMap<>();
     for (FieldError error : ex.getBindingResult().getFieldErrors()) {
       fieldErrors.put(error.getField(), error.getDefaultMessage());
     }
     errorResponse.put("fieldErrors", fieldErrors);
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(errorResponse);
+  }
 
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<Map<String, Object>> handleConstraintViolationException(
+      ConstraintViolationException ex) {
+    Map<String, Object> errorResponse = new LinkedHashMap<>();
+    errorResponse.put("error", "バリデーションエラー");
+    Map<String, String> fieldErrors = new LinkedHashMap<>();
+    ex.getConstraintViolations().forEach(violation -> {
+      fieldErrors.put(violation.getPropertyPath().toString(), violation.getMessage());
+    });
+    errorResponse.put("fieldErrors", fieldErrors);
     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
         .body(errorResponse);
   }
@@ -44,7 +56,6 @@ public class GlobalExceptionHandler {
     Map<String, String> errorResponse = new LinkedHashMap<>();
     errorResponse.put("error", "予期しないエラー");
     errorResponse.put("message", ex.getMessage());
-
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
         .body(errorResponse);
   }

--- a/src/test/java/raisetech/StudentManagementSystem/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/StudentManagementSystem/controller/StudentControllerTest.java
@@ -1,7 +1,9 @@
 package raisetech.StudentManagementSystem.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -23,6 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import raisetech.StudentManagementSystem.data.Student;
 import raisetech.StudentManagementSystem.domain.Gender;
 import raisetech.StudentManagementSystem.domain.StudentDetail;
+import raisetech.StudentManagementSystem.exception.CustomAppException;
 import raisetech.StudentManagementSystem.service.StudentService;
 
 @WebMvcTest(StudentController.class)
@@ -38,46 +41,19 @@ class StudentControllerTest {
   private StudentService service;
 
   @Test
-  void 受講生詳細の一覧検索ができて空のリストが返ってくること() throws Exception {
-    // モックの挙動を定義
+  void 正常系_受講生詳細一覧を検索すると空のリストが返ること() throws Exception {
     when(service.listStudentDetails()).thenReturn(Collections.emptyList());
 
     mockMvc.perform(get("/students"))
         .andExpect(status().isOk())
-        .andExpect(content().json("[]"));  // 空のリストは "[]" として返される
+        .andExpect(content().json("[]"));
 
     verify(service, times(1)).listStudentDetails();
   }
 
   @Test
-  void 受講生登録が正常にできること() throws Exception {
-    // テスト用データの作成（必須項目をすべてセット）
-    Student student = new Student();
-    student.setName("テスト太郎");
-    student.setKanaName("テストタロウ");
-    student.setAge(20);
-    student.setEmail("test@example.com");
-    student.setRegion("Tokyo");
-    // Gender が enum の場合、適切な定数を設定
-    student.setGender(Gender.MALE);
-
-    StudentDetail studentDetail = new StudentDetail();
-    studentDetail.setStudent(student);
-
-    // POSTリクエストを実施
-    mockMvc.perform(post("/students")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(studentDetail)))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.message").value("テスト太郎さんが新規受講生として登録されました。"))
-        .andExpect(jsonPath("$.studentDetail.student.name").value("テスト太郎"));
-
-    verify(service, times(1)).registerStudent(any(StudentDetail.class));
-  }
-
-  @Test
-  void 学生情報取得ができること() throws Exception {
-    int id = 1;
+  void 正常系_存在しない受講生IDを検索すると空のデータが返ること() throws Exception {
+    int id = 999;
     Student student = new Student();
     student.setId(id);
     student.setName("テスト花子");
@@ -94,19 +70,50 @@ class StudentControllerTest {
   }
 
   @Test
-  void 学生情報更新が正常にできること() throws Exception {
+  void 正常系_受講生詳細を登録すると入力データがそのままレスポンスに含まれること()
+      throws Exception {
+    // リクエストデータを適切に構築（入力チェックも兼ねる）
+    // ※本来は、登録後にDBから最新のデータが返るが、モック化しているため、入力データがそのままレスポンスに反映される
+    Student student = new Student();
+    student.setName("テスト太郎");
+    student.setKanaName("テストタロウ");
+    student.setAge(20);
+    student.setEmail("test@example.com");
+    student.setRegion("Tokyo");
+    student.setGender(Gender.MALE);
+
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudent(student);
+
+    // サービス層はvoidメソッドのため、戻り値の設定は不要
+    mockMvc.perform(post("/students")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(studentDetail)))
+        .andExpect(status().isOk())
+        // 入力された名前に基づくメッセージが返ることを検証
+        .andExpect(jsonPath("$.message").value("テスト太郎さんが新規受講生として登録されました。"))
+        // リクエスト時のstudent情報がレスポンスにエコーされることを検証
+        .andExpect(jsonPath("$.studentDetail.student.name").value("テスト太郎"));
+
+    // バリデーションも兼ねているため、サービス層の登録処理が実行されたことを検証
+    verify(service, times(1)).registerStudent(any(StudentDetail.class));
+  }
+
+  @Test
+  void 正常系_受講生詳細を更新すると成功メッセージが返ること() throws Exception {
     int id = 1;
     Student student = new Student();
-    // 更新用データ：必須項目をすべてセット
     student.setName("更新太郎");
     student.setKanaName("更新タロウ");
     student.setAge(25);
     student.setEmail("update@example.com");
     student.setRegion("Osaka");
-    student.setGender(Gender.MALE);  // Gender が enum の場合
-
+    student.setGender(Gender.MALE);
     StudentDetail studentDetail = new StudentDetail();
     studentDetail.setStudent(student);
+
+    // voidメソッドなので、doNothing()でモックの挙動を設定
+    doNothing().when(service).updateStudent(any(StudentDetail.class));
 
     mockMvc.perform(put("/students/{id}", id)
             .contentType(MediaType.APPLICATION_JSON)
@@ -114,12 +121,78 @@ class StudentControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().string("更新太郎さんの受講生情報が更新されました。"));
 
-    // コントローラー内部でリクエストパスの id をセットしているため、引数検証を実施
     verify(service, times(1)).updateStudent(argThat(detail ->
         detail.getStudent() != null &&
             detail.getStudent().getId() != null &&
             detail.getStudent().getId().intValue() == id &&
             "更新太郎".equals(detail.getStudent().getName())
     ));
+  }
+
+  @Test
+  void 異常系_受講生登録時にバリデーションエラーが発生するとエラーメッセージが返ること()
+      throws Exception {
+    // 必須項目が不足している不正なデータを作成（例：nameやkanaNameが未設定）
+    Student student = new Student();
+    // student.setName(null);  // ※nullや空文字の場合、@NotNullの制約でエラーとなる前提
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudent(student);
+
+    mockMvc.perform(post("/students")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(studentDetail)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error").value("バリデーションエラー"))
+        .andExpect(jsonPath("$.fieldErrors").exists());
+
+    // バリデーションエラーの場合、サービス層は呼ばれない
+    verify(service, times(0)).registerStudent(any(StudentDetail.class));
+  }
+
+  @Test
+  void 異常系_不正なIDで受講生詳細を取得するとバリデーションエラーが発生すること()
+      throws Exception {
+    int invalidId = 0;  // @Min(1) に違反する値
+    mockMvc.perform(get("/students/{id}", invalidId))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error").value("バリデーションエラー"))
+        .andExpect(jsonPath("$.fieldErrors").exists());
+
+    // バリデーションエラーの場合、サービス層は呼ばれない
+    verify(service, times(0)).getStudentDetailById(anyInt());
+  }
+
+  @Test
+  void 異常系_受講生詳細を更新する際にバリデーションエラーが発生するとエラーメッセージが返ること()
+      throws Exception {
+    int id = 1;
+    // 不正な更新データ（必須項目が不足）
+    Student student = new Student();
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudent(student);
+
+    mockMvc.perform(put("/students/{id}", id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(studentDetail)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error").value("バリデーションエラー"))
+        .andExpect(jsonPath("$.fieldErrors").exists());
+
+    verify(service, times(0)).updateStudent(any(StudentDetail.class));
+  }
+
+  @Test
+  void 異常系_存在しない受講生IDを検索するとCustomAppExceptionが発生しエラーレスポンスが返ること()
+      throws Exception {
+    int id = 999; // 存在しないIDなど
+    when(service.getStudentDetailById(id))
+        .thenThrow(new CustomAppException("学生情報が見つかりません。"));
+    
+    mockMvc.perform(get("/students/{id}", id))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error").value("エラーメッセージ"))
+        .andExpect(jsonPath("$.message").value("学生情報が見つかりません。"));
+
+    verify(service, times(1)).getStudentDetailById(id);
   }
 }

--- a/src/test/java/raisetech/StudentManagementSystem/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/StudentManagementSystem/controller/StudentControllerTest.java
@@ -50,25 +50,7 @@ class StudentControllerTest {
 
     verify(service, times(1)).listStudentDetails();
   }
-
-  @Test
-  void 正常系_存在しない受講生IDを検索すると空のデータが返ること() throws Exception {
-    int id = 999;
-    Student student = new Student();
-    student.setId(id);
-    student.setName("テスト花子");
-    StudentDetail studentDetail = new StudentDetail();
-    studentDetail.setStudent(student);
-
-    when(service.getStudentDetailById(id)).thenReturn(studentDetail);
-
-    mockMvc.perform(get("/students/{id}", id))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.student.name").value("テスト花子"));
-
-    verify(service, times(1)).getStudentDetailById(id);
-  }
-
+  
   @Test
   void 正常系_受講生詳細を登録すると入力データがそのままレスポンスに含まれること()
       throws Exception {
@@ -187,7 +169,7 @@ class StudentControllerTest {
     int id = 999; // 存在しないIDなど
     when(service.getStudentDetailById(id))
         .thenThrow(new CustomAppException("学生情報が見つかりません。"));
-    
+
     mockMvc.perform(get("/students/{id}", id))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.error").value("エラーメッセージ"))

--- a/src/test/java/raisetech/StudentManagementSystem/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/StudentManagementSystem/controller/StudentControllerTest.java
@@ -1,0 +1,125 @@
+package raisetech.StudentManagementSystem.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import raisetech.StudentManagementSystem.data.Student;
+import raisetech.StudentManagementSystem.domain.Gender;
+import raisetech.StudentManagementSystem.domain.StudentDetail;
+import raisetech.StudentManagementSystem.service.StudentService;
+
+@WebMvcTest(StudentController.class)
+class StudentControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private StudentService service;
+
+  @Test
+  void 受講生詳細の一覧検索ができて空のリストが返ってくること() throws Exception {
+    // モックの挙動を定義
+    when(service.listStudentDetails()).thenReturn(Collections.emptyList());
+
+    mockMvc.perform(get("/students"))
+        .andExpect(status().isOk())
+        .andExpect(content().json("[]"));  // 空のリストは "[]" として返される
+
+    verify(service, times(1)).listStudentDetails();
+  }
+
+  @Test
+  void 受講生登録が正常にできること() throws Exception {
+    // テスト用データの作成（必須項目をすべてセット）
+    Student student = new Student();
+    student.setName("テスト太郎");
+    student.setKanaName("テストタロウ");
+    student.setAge(20);
+    student.setEmail("test@example.com");
+    student.setRegion("Tokyo");
+    // Gender が enum の場合、適切な定数を設定
+    student.setGender(Gender.MALE);
+
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudent(student);
+
+    // POSTリクエストを実施
+    mockMvc.perform(post("/students")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(studentDetail)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value("テスト太郎さんが新規受講生として登録されました。"))
+        .andExpect(jsonPath("$.studentDetail.student.name").value("テスト太郎"));
+
+    verify(service, times(1)).registerStudent(any(StudentDetail.class));
+  }
+
+  @Test
+  void 学生情報取得ができること() throws Exception {
+    int id = 1;
+    Student student = new Student();
+    student.setId(id);
+    student.setName("テスト花子");
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudent(student);
+
+    when(service.getStudentDetailById(id)).thenReturn(studentDetail);
+
+    mockMvc.perform(get("/students/{id}", id))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.student.name").value("テスト花子"));
+
+    verify(service, times(1)).getStudentDetailById(id);
+  }
+
+  @Test
+  void 学生情報更新が正常にできること() throws Exception {
+    int id = 1;
+    Student student = new Student();
+    // 更新用データ：必須項目をすべてセット
+    student.setName("更新太郎");
+    student.setKanaName("更新タロウ");
+    student.setAge(25);
+    student.setEmail("update@example.com");
+    student.setRegion("Osaka");
+    student.setGender(Gender.MALE);  // Gender が enum の場合
+
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudent(student);
+
+    mockMvc.perform(put("/students/{id}", id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(studentDetail)))
+        .andExpect(status().isOk())
+        .andExpect(content().string("更新太郎さんの受講生情報が更新されました。"));
+
+    // コントローラー内部でリクエストパスの id をセットしているため、引数検証を実施
+    verify(service, times(1)).updateStudent(argThat(detail ->
+        detail.getStudent() != null &&
+            detail.getStudent().getId() != null &&
+            detail.getStudent().getId().intValue() == id &&
+            "更新太郎".equals(detail.getStudent().getName())
+    ));
+  }
+}

--- a/src/test/java/raisetech/StudentManagementSystem/controller/converter/StudentConverterTest.java
+++ b/src/test/java/raisetech/StudentManagementSystem/controller/converter/StudentConverterTest.java
@@ -1,0 +1,97 @@
+package raisetech.StudentManagementSystem.controller.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import raisetech.StudentManagementSystem.data.Student;
+import raisetech.StudentManagementSystem.data.StudentsCourses;
+import raisetech.StudentManagementSystem.domain.Gender;
+import raisetech.StudentManagementSystem.domain.StudentDetail;
+
+public class StudentConverterTest {
+
+  private StudentConverter sut;
+
+  @BeforeEach
+  void before() {
+    sut = new StudentConverter();
+  }
+
+  @Test
+  void 受講生のリストと受講生コース情報のリストを渡して受講生詳細のリストが作成できること() {
+    // 受講生データの作成
+    Student student = createStudent();
+
+    // 受講コースデータの作成
+    StudentsCourses studentsCourses = new StudentsCourses();
+    studentsCourses.setId(1);
+    studentsCourses.setStudentId(1);
+    studentsCourses.setCourseName("新しいコース");
+    studentsCourses.setStartDateAt(LocalDate.parse("2025-03-01"));
+    studentsCourses.setEndDateAt(LocalDate.parse("2025-06-01"));
+
+    List<Student> students = List.of(student);
+    List<StudentsCourses> courses = List.of(studentsCourses);
+
+    // メソッド実行
+    List<StudentDetail> result = sut.convertToStudentDetailList(students, courses);
+
+    // 検証
+    assertThat(result).hasSize(1);
+    StudentDetail studentDetail = result.get(0);
+    assertThat(studentDetail.getStudent()).isEqualTo(student);
+    assertThat(studentDetail.getCourseList()).containsExactly(studentsCourses);
+  }
+
+  @Test
+  void 受講生のリストと受講生コース情報のリストを渡した時に紐づかない受講生コース情報は除外されること() {
+    // 受講生データの作成（ID:1 の受講生）
+    Student student = createStudent();
+
+    // 受講生と紐づくコース情報（studentId = 1）
+    StudentsCourses matchingCourse = new StudentsCourses();
+    matchingCourse.setId(1);
+    matchingCourse.setStudentId(1);
+    matchingCourse.setCourseName("新しいコース");
+    matchingCourse.setStartDateAt(LocalDate.parse("2025-03-01"));
+    matchingCourse.setEndDateAt(LocalDate.parse("2025-06-01"));
+
+    // 受講生と紐づかないコース情報（studentId = 1000）
+    StudentsCourses nonMatchingCourse = new StudentsCourses();
+    nonMatchingCourse.setId(1000);
+    nonMatchingCourse.setStudentId(1000);
+    nonMatchingCourse.setCourseName("マーケティング");
+    nonMatchingCourse.setStartDateAt(LocalDate.parse("2025-03-01"));
+    nonMatchingCourse.setEndDateAt(null);
+
+    List<Student> students = List.of(student);
+    List<StudentsCourses> courses = List.of(matchingCourse, nonMatchingCourse);
+
+    // メソッド実行
+    List<StudentDetail> result = sut.convertToStudentDetailList(students, courses);
+
+    // 検証：受講生詳細は1件で、受講生と紐づくコース情報のみが含まれること
+    assertThat(result).hasSize(1);
+    StudentDetail studentDetail = result.get(0);
+    assertThat(studentDetail.getStudent()).isEqualTo(student);
+    assertThat(studentDetail.getCourseList()).containsExactly(matchingCourse);
+  }
+
+  private static Student createStudent() {
+    Student student = new Student();
+    student.setId(1);
+    student.setName("室伏 広治");
+    student.setKanaName("むろぶし こうじ");
+    student.setNickname("Koji Murobushi");
+    student.setAge(78);
+    student.setEmail("koji.muro@example.com");
+    student.setRegion("川");
+    student.setGender(Gender.FEMALE);
+    student.setRemark("");
+    student.setIsDeleted(false);
+    return student;
+  }
+}

--- a/src/test/java/raisetech/StudentManagementSystem/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/StudentManagementSystem/service/StudentServiceTest.java
@@ -46,15 +46,21 @@ class StudentServiceTest {
   void コース情報も含む受講生情報の全件検索_リポジトリとコンバーターの処理が適切に呼び出せていること() {
     List<Student> students = new ArrayList<>();
     List<StudentsCourses> studentsCourses = new ArrayList<>();
+    List<StudentDetail> expectedDetails = new ArrayList<>();
+
     when(repository.search()).thenReturn(students);
     when(repository.searchStudentsCourses()).thenReturn(studentsCourses);
+    when(converter.convertToStudentDetailList(students, studentsCourses)).thenReturn(
+        expectedDetails);
 
-    sut.listStudentDetails();
+    List<StudentDetail> result = sut.listStudentDetails();
 
+    assertSame(expectedDetails, result); // 返り値のチェック追加
     verify(repository, times(1)).search();
     verify(repository, times(1)).searchStudentsCourses();
     verify(converter, times(1)).convertToStudentDetailList(students, studentsCourses);
   }
+
 
   @Test
   void 学生一覧検索_リポジトリのsearchメソッドが呼び出されること() {
@@ -132,8 +138,10 @@ class StudentServiceTest {
     // 各コースに学生IDがセットされ、登録処理が呼ばれていること
     verify(repository, times(1)).registerStudentsCourses(course1);
     verify(repository, times(1)).registerStudentsCourses(course2);
-    assertEquals(1, course1.getStudentId());
+
+    assertEquals(1, course1.getStudentId()); // 学生IDが正しくセットされているか
     assertEquals(1, course2.getStudentId());
+    assertNotNull(studentDetail.getCourseList()); // コースリストがnullでないことを確認
   }
 
   @Test


### PR DESCRIPTION
# StudentConverterTest の変更点まとめ

## 1. **パッケージ宣言の追加**
   - `package raisetech.StudentManagementSystem.controller.converter;` を追加し、適切なパッケージに所属させた。

## 2. **JUnit のアサーションライブラリの変更**
   - `org.junit.jupiter.api.Assertions` から `org.assertj.core.api.Assertions.assertThat` へ変更し、`AssertJ` を使用するように統一。

## 3. **テストクラスの正式な構成**
   - `StudentConverterTest` を正式な JUnit テストクラスとして定義。
   - `@BeforeEach` を使用して `StudentConverter` のインスタンスを初期化。

## 4. **テストケースの追加**
   - **受講生リストと受講生コース情報リストを渡して、受講生詳細リストが作成されることのテスト**
     - `convertToStudentDetailList()` の正常動作を確認するテストを追加。

   - **受講生リストと受講生コース情報リストを渡した際に、紐づかないコース情報が除外されることのテスト**
     - `convertToStudentDetailList()` が、受講生と関連しないコース情報を除外することを確認するテストを追加。

## 5. **ヘルパーメソッドの追加**
   - 受講生データ (`Student`) を作成する `createStudent()` メソッドを追加し、テストコードの可読性を向上。

## コンバーターテストの結果確認について
build/reports/index.htmlでコンバーターテストの結果を確認しました。全てのテストが成功していることを確認しています。このテストレポートでは、各テストケースの結果が視覚的に表示されており、エラーや失敗の詳細も見ることができました。
![スクリーンショット 2025-03-18 213732](https://github.com/user-attachments/assets/43f82d8c-20e3-415c-be02-17ce1efe2971)

