### PR TITLE
コースを追加する処理を実装

### DIFF
--- a/src/main/java/raisetech/StudentManagementSystem/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagementSystem/controller/StudentController.java
@@ -36,14 +36,16 @@ public class StudentController {
 
   @Operation(summary = "一覧検索", description = "すべての受講生情報（受講コース情報含む）を取得する")
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "学生情報のリストが返される")
-  })
+      @ApiResponse(responseCode = "200", description = "学生情報のリストが返される")})
   @GetMapping
-  public List<StudentDetail> listStudents() {
-    return service.listStudentDetails();
+  public ResponseEntity<Map<String, Object>> listStudents() {
+    List<StudentDetail> students = service.listStudentDetails();
+    Map<String, Object> response = new HashMap<>();
+    response.put("students", students);
+    return ResponseEntity.ok(response);
   }
 
-  @Operation(summary = "受講生登録", description = "新規の受講生を登録する。登録する学生の詳細情報（受講コース情報含む）を受け取り、登録結果のメッセージと学生情報を返す")
+  @Operation(summary = "受講生登録", description = "新規の受講生を登録する")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "登録成功。メッセージと登録された学生情報が返される"),
       @ApiResponse(responseCode = "400", description = "入力エラー")
@@ -52,37 +54,38 @@ public class StudentController {
   public ResponseEntity<Map<String, Object>> registerStudent(
       @Valid @RequestBody StudentDetail studentDetail) {
     service.registerStudent(studentDetail);
-
     Map<String, Object> response = new HashMap<>();
     response.put("message",
         studentDetail.getStudent().getName() + "さんが新規受講生として登録されました。");
     response.put("studentDetail", studentDetail);
-
     return ResponseEntity.ok(response);
   }
 
-  @Operation(summary = "学生情報取得", description = "指定されたIDの学生情報を取得する。学生IDは1以上の整数である必要がある")
+  @Operation(summary = "学生情報取得", description = "指定されたIDの学生情報を取得する")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "指定された学生の詳細情報が返される"),
       @ApiResponse(responseCode = "400", description = "入力されたIDが無効")
   })
   @GetMapping("/{id}")
-  public ResponseEntity<StudentDetail> getStudentDetail(@PathVariable @Min(1) int id) {
+  public ResponseEntity<Map<String, Object>> getStudentDetail(@PathVariable @Min(1) int id) {
     StudentDetail studentDetail = service.getStudentDetailById(id);
-    return ResponseEntity.ok(studentDetail);
+    Map<String, Object> response = new HashMap<>();
+    response.put("studentDetail", studentDetail);
+    return ResponseEntity.ok(response);
   }
 
-  @Operation(summary = "学生情報更新", description = "指定されたIDの学生情報を更新する。更新後の学生情報をリクエストボディで受け取る")
+  @Operation(summary = "学生情報更新", description = "指定されたIDの学生情報を更新する")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "更新成功。更新完了メッセージが返される"),
       @ApiResponse(responseCode = "400", description = "入力エラー")
   })
   @PutMapping("/{id}")
-  public ResponseEntity<String> updateStudent(
-      @PathVariable int id,
+  public ResponseEntity<Map<String, Object>> updateStudent(@PathVariable int id,
       @RequestBody @Valid StudentDetail studentDetail) {
     service.updateStudent(id, studentDetail);
-    return ResponseEntity.ok("学生情報を更新しました");
+    Map<String, Object> response = new HashMap<>();
+    response.put("message", "学生情報を更新しました");
+    return ResponseEntity.ok(response);
   }
 
   @Operation(summary = "受講生にコースを追加", description = "指定された受講生に新しいコースを追加する")
@@ -91,9 +94,11 @@ public class StudentController {
       @ApiResponse(responseCode = "400", description = "入力エラー")
   })
   @PostMapping("/{id}/courses")
-  public ResponseEntity<String> addCourseForStudent(@PathVariable @Min(1) int id,
+  public ResponseEntity<Map<String, Object>> addCourseForStudent(@PathVariable @Min(1) int id,
       @Valid @RequestBody StudentsCourses sc) {
     service.addCourseForStudent(id, sc);
-    return ResponseEntity.ok("新しいコースが追加されました。");
+    Map<String, Object> response = new HashMap<>();
+    response.put("message", "新しいコースが追加されました。");
+    return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/raisetech/StudentManagementSystem/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagementSystem/controller/StudentController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import raisetech.StudentManagementSystem.data.StudentsCourses;
 import raisetech.StudentManagementSystem.domain.StudentDetail;
 import raisetech.StudentManagementSystem.service.StudentService;
 
@@ -77,11 +78,22 @@ public class StudentController {
       @ApiResponse(responseCode = "400", description = "入力エラー")
   })
   @PutMapping("/{id}")
-  public ResponseEntity<String> updateStudent(@PathVariable @Min(1) int id,
-      @Valid @RequestBody StudentDetail studentDetail) {
-    studentDetail.getStudent().setId(id);
-    service.updateStudent(studentDetail);
-    return ResponseEntity.ok(
-        studentDetail.getStudent().getName() + "さんの受講生情報が更新されました。");
+  public ResponseEntity<String> updateStudent(
+      @PathVariable int id,
+      @RequestBody @Valid StudentDetail studentDetail) {
+    service.updateStudent(id, studentDetail);
+    return ResponseEntity.ok("学生情報を更新しました");
+  }
+
+  @Operation(summary = "受講生にコースを追加", description = "指定された受講生に新しいコースを追加する")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "コース追加成功"),
+      @ApiResponse(responseCode = "400", description = "入力エラー")
+  })
+  @PostMapping("/{id}/courses")
+  public ResponseEntity<String> addCourseForStudent(@PathVariable @Min(1) int id,
+      @Valid @RequestBody StudentsCourses sc) {
+    service.addCourseForStudent(id, sc);
+    return ResponseEntity.ok("新しいコースが追加されました。");
   }
 }

--- a/src/main/java/raisetech/StudentManagementSystem/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagementSystem/controller/StudentController.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Min;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import raisetech.StudentManagementSystem.data.Student;
 import raisetech.StudentManagementSystem.data.StudentsCourses;
 import raisetech.StudentManagementSystem.domain.StudentDetail;
 import raisetech.StudentManagementSystem.service.StudentService;
@@ -74,18 +76,49 @@ public class StudentController {
     return ResponseEntity.ok(response);
   }
 
-  @Operation(summary = "学生情報更新", description = "指定されたIDの学生情報を更新する")
+  @Operation(summary = "学生基本情報更新", description = "指定されたIDの学生基本情報を更新する")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "更新成功。更新完了メッセージが返される"),
       @ApiResponse(responseCode = "400", description = "入力エラー")
   })
   @PutMapping("/{id}")
-  public ResponseEntity<Map<String, Object>> updateStudent(@PathVariable int id,
-      @RequestBody @Valid StudentDetail studentDetail) {
-    service.updateStudent(id, studentDetail);
+  public ResponseEntity<Map<String, Object>> updateStudentBasicInfo(
+      @PathVariable int id,
+      @RequestBody @Valid Student student) {
+    // URLのIDを受け取って、リクエストボディの学生情報にセットする
+    student.setId(id);
+    service.updateStudentBasicInfo(student);
     Map<String, Object> response = new HashMap<>();
-    response.put("message", "学生情報を更新しました");
+    response.put("message", "学生基本情報を更新しました");
     return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "受講コース情報更新", description = "指定された学生の特定の受講コース情報を更新する")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "更新成功。更新完了メッセージが返される"),
+      @ApiResponse(responseCode = "400", description = "入力エラー"),
+      @ApiResponse(responseCode = "500", description = "サーバーエラー")
+  })
+  @PutMapping("/{studentId}/courses/{courseId}")
+  public ResponseEntity<Map<String, Object>> updateStudentCourse(
+      @PathVariable int studentId,
+      @PathVariable int courseId,
+      @RequestBody @Valid StudentsCourses course) {
+
+    // URLのcourseIdとstudentIdを設定。BodyにはIDは含めない。
+    course.setId(courseId);
+    course.setStudentId(studentId);
+
+    Map<String, Object> response = new HashMap<>();
+
+    try {
+      service.updateStudentCourse(studentId, course);
+      response.put("message", "受講コース情報を更新しました");
+      return ResponseEntity.ok(response);
+    } catch (Exception e) {
+      response.put("message", "更新に失敗しました: " + e.getMessage());
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
   }
 
   @Operation(summary = "受講生にコースを追加", description = "指定された受講生に新しいコースを追加する")

--- a/src/main/java/raisetech/StudentManagementSystem/data/StudentsCourses.java
+++ b/src/main/java/raisetech/StudentManagementSystem/data/StudentsCourses.java
@@ -8,7 +8,9 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.ibatis.type.Alias;
 
+@Alias("StudentsCourses")
 @Schema(description = "受講生コース情報")
 @Getter
 @Setter

--- a/src/main/java/raisetech/StudentManagementSystem/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagementSystem/repository/StudentRepository.java
@@ -31,4 +31,7 @@ public interface StudentRepository {
 
   // 学生のコース情報を更新（id で特定のコースのみ更新）
   void updateStudentsCourses(StudentsCourses sc);
+
+  // コースを追加
+  void insertStudentsCourses(StudentsCourses sc);
 }

--- a/src/main/java/raisetech/StudentManagementSystem/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagementSystem/repository/StudentRepository.java
@@ -34,4 +34,7 @@ public interface StudentRepository {
 
   // コースを追加
   void insertStudentsCourses(StudentsCourses sc);
+
+  // 受講コースIDで受講コース情報を取得する
+  StudentsCourses findCourseById(int courseId);
 }

--- a/src/main/java/raisetech/StudentManagementSystem/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagementSystem/service/StudentService.java
@@ -12,7 +12,6 @@ import raisetech.StudentManagementSystem.domain.StudentDetail;
 import raisetech.StudentManagementSystem.exception.CustomAppException;
 import raisetech.StudentManagementSystem.repository.StudentRepository;
 
-
 @Service
 public class StudentService {
 
@@ -26,7 +25,7 @@ public class StudentService {
   }
 
   /**
-   * 学生の一覧を検索する
+   * 学生の一覧を検索する。
    *
    * @return 学生のリスト
    */
@@ -35,7 +34,7 @@ public class StudentService {
   }
 
   /**
-   * 受講コースの一覧を検索する
+   * 受講コースの一覧を検索する。
    *
    * @return 受講コースのリスト
    */
@@ -44,7 +43,7 @@ public class StudentService {
   }
 
   /**
-   * 学生情報（受講コース情報を含む）を取得する
+   * 学生情報（受講コース情報含む）を取得する。
    *
    * @return 学生詳細情報のリスト
    */
@@ -55,43 +54,40 @@ public class StudentService {
   }
 
   /**
-   * 指定されたIDの学生詳細情報を取得する
+   * 指定されたIDの学生詳細情報を取得する。
    *
    * @param id 学生ID
    * @return 学生詳細情報
-   * @throws CustomAppException 学生が見つからない場合に例外をスロー
+   * @throws CustomAppException 指定された学生が存在しない場合にスローされる
    */
   public StudentDetail getStudentDetailById(int id) {
     Student student = repository.findById(id);
     if (student == null) {
       throw new CustomAppException("指定された受講生が見つかりませんでした。");
     }
-
     List<StudentsCourses> courses = repository.findCoursesByStudentId(id);
     StudentDetail studentDetail = new StudentDetail();
     studentDetail.setStudent(student);
     studentDetail.setCourseList(courses != null ? courses : new ArrayList<>());
-
     return studentDetail;
   }
 
   /**
-   * 新規の学生を登録する
+   * 新規の学生を登録する。
    *
-   * @param studentDetail 登録する学生の詳細情報
+   * @param studentDetail 登録する学生の詳細情報（受講コース情報含む）
    */
   @Transactional
   public void registerStudent(StudentDetail studentDetail) {
     // 学生情報の登録
     repository.registerStudent(studentDetail.getStudent());
-
-    // 学生IDを取得し、受講コース情報を登録
+    // 登録後、生成された学生IDを取得し、受講コース情報を登録する
     int studentId = studentDetail.getStudent().getId();
     initStudentsCourse(studentDetail, studentId);
   }
 
   /**
-   * 受講コース情報を初期化し、学生IDを設定して登録する
+   * 受講コース情報を初期化し、学生IDを設定して登録する。
    *
    * @param studentDetail 学生詳細情報
    * @param studentId     学生ID
@@ -106,63 +102,61 @@ public class StudentService {
   }
 
   /**
-   * 学生情報を更新する
+   * 学生の基本情報を更新する。 指定された学生IDに対応する学生情報が存在するかをチェックし、 存在する場合は基本情報を更新する。
+   * リクエストボディにはIDが含まれないため、URLから受け取ったIDを設定する。
    *
-   * @param studentDetail 更新する学生の詳細情報
-   * @throws CustomAppException 学生が存在しない場合、またはコースIDが提供されていない場合に例外をスロー
+   * @param student 更新する学生の基本情報（IDはURLから設定される）
+   * @throws CustomAppException 更新対象の学生が存在しない場合にスローされる
    */
-  public void updateStudent(int id, StudentDetail studentDetail) {
-    // リクエストURLのIDとボディ内のIDが一致するかチェック
-    if (studentDetail.getStudent().getId() != id) {
-      throw new CustomAppException("リクエストURLのIDとボディ内のIDが一致しません。");
-    }
-
-    // 更新対象の学生が存在するかチェック
-    if (repository.findById(studentDetail.getStudent().getId()) == null) {
+  public void updateStudentBasicInfo(Student student) {
+    if (repository.findById(student.getId()) == null) {
       throw new CustomAppException("更新対象の学生が存在しません");
     }
-
-    // 学生情報の更新
-    repository.updateStudent(studentDetail.getStudent());
-
-    // 受講コース情報の更新
-    if (studentDetail.getCourseList() != null) {
-      for (StudentsCourses sc : studentDetail.getCourseList()) {
-        sc.setStudentId(studentDetail.getStudent().getId());
-
-        // コースIDが提供されていない場合は例外をスロー
-        if (sc.getId() == null) {
-          throw new CustomAppException("更新対象のコースIDが提供されていません");
-        } else {
-          repository.updateStudentsCourses(sc);
-        }
-      }
-    }
+    repository.updateStudent(student);
   }
 
   /**
-   * 学生に新しいコースを追加する
+   * 受講コース情報を更新する。 URLから受け取った学生IDと、更新対象のコースIDに基づいて、対象コース情報が存在するかを確認し、 その受講コース情報を更新する。
    *
-   * @param studentId 学生ID
-   * @param sc        受講するコース情報
+   * @param studentId URLから取得した学生ID
+   * @param course    更新する受講コース情報。リクエストボディにはIDが含まれないため、URLのcourseIdをセットする。
+   * @throws CustomAppException 更新対象のコースが存在しない、またはURLの学生IDと更新対象コースの学生IDが一致しない場合にスローされる
+   */
+  @Transactional
+  public void updateStudentCourse(int studentId, StudentsCourses course) {
+    // まず、更新対象のコース情報をDBから取得
+    StudentsCourses existingCourse = repository.findCourseById(course.getId());
+    if (existingCourse == null) {
+      throw new CustomAppException("更新対象のコースが存在しません");
+    }
+    // URLの学生IDと、取得したコース情報の学生IDが一致するかチェック
+    if (!existingCourse.getStudentId().equals(studentId)) {
+      throw new CustomAppException("URL の学生IDと、更新対象のコースの学生IDが一致しません");
+    }
+    // 整合性が確認できたら更新処理を実行
+    repository.updateStudentsCourses(course);
+  }
+
+  /**
+   * 学生に新しい受講コース情報を追加する。 指定された学生IDの学生が存在するかをチェックし、受講コースの追加可能件数（最大3件）や
+   * 開始日・終了日の条件を検証した上で、新しいコース情報を登録する。
+   *
+   * @param studentId 更新対象の学生ID
+   * @param sc        追加する受講コース情報（IDはリクエストボディに含めない）
+   * @throws CustomAppException 受講生が存在しない、または既存のコース数が最大件数に達している場合、または開始日条件に合致しない場合にスローされる
    */
   @Transactional
   public void addCourseForStudent(int studentId, StudentsCourses sc) {
-    // 学生が存在するか確認
     Student student = repository.findById(studentId);
     if (student == null) {
       throw new CustomAppException("指定された学生が存在しません。");
     }
-
-    // 既存のコース情報を取得
     List<StudentsCourses> existingCourses = repository.findCoursesByStudentId(studentId);
     if (existingCourses.size() >= 3) {
       throw new CustomAppException("受講生は最大3つのコースしか受講できません。");
     }
-
     if (sc.getStartDateAt() != null) {
       for (StudentsCourses existingCourse : existingCourses) {
-        // 終了日時が未設定の場合も未終了と判断する
         if (existingCourse.getEndDateAt() == null ||
             sc.getStartDateAt().isBefore(existingCourse.getEndDateAt())) {
           throw new CustomAppException(
@@ -170,11 +164,7 @@ public class StudentService {
         }
       }
     }
-
-    // コースの学生IDを設定
     sc.setStudentId(studentId);
-
-    // コースを登録
     repository.insertStudentsCourses(sc);
   }
 }

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -79,4 +79,10 @@
     WHERE id = #{id}
   </update>
 
+  <!-- コースを追加 -->
+  <insert id="insertStudentsCourses" parameterType="StudentsCourses">
+    INSERT INTO students_courses (student_id, course_name, start_date_at, end_date_at)
+    VALUES (#{studentId}, #{courseName}, #{startDateAt}, #{endDateAt});
+  </insert>
+
 </mapper>

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -85,4 +85,9 @@
     VALUES (#{studentId}, #{courseName}, #{startDateAt}, #{endDateAt});
   </insert>
 
+  <!-- 受講コースIDで受講コース情報を取得 -->
+  <select id="findCourseById" resultType="raisetech.StudentManagementSystem.data.StudentsCourses">
+    SELECT * FROM students_courses WHERE id = #{courseId}
+  </select>
+
 </mapper>

--- a/src/test/java/raisetech/StudentManagementSystem/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/StudentManagementSystem/controller/StudentControllerTest.java
@@ -3,6 +3,7 @@ package raisetech.StudentManagementSystem.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -50,12 +51,11 @@ class StudentControllerTest {
 
     verify(service, times(1)).listStudentDetails();
   }
-  
+
   @Test
   void 正常系_受講生詳細を登録すると入力データがそのままレスポンスに含まれること()
       throws Exception {
-    // リクエストデータを適切に構築（入力チェックも兼ねる）
-    // ※本来は、登録後にDBから最新のデータが返るが、モック化しているため、入力データがそのままレスポンスに反映される
+    // リクエストデータ
     Student student = new Student();
     student.setName("テスト太郎");
     student.setKanaName("テストタロウ");
@@ -67,46 +67,45 @@ class StudentControllerTest {
     StudentDetail studentDetail = new StudentDetail();
     studentDetail.setStudent(student);
 
-    // サービス層はvoidメソッドのため、戻り値の設定は不要
     mockMvc.perform(post("/students")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(studentDetail)))
         .andExpect(status().isOk())
-        // 入力された名前に基づくメッセージが返ることを検証
         .andExpect(jsonPath("$.message").value("テスト太郎さんが新規受講生として登録されました。"))
-        // リクエスト時のstudent情報がレスポンスにエコーされることを検証
         .andExpect(jsonPath("$.studentDetail.student.name").value("テスト太郎"));
 
-    // バリデーションも兼ねているため、サービス層の登録処理が実行されたことを検証
     verify(service, times(1)).registerStudent(any(StudentDetail.class));
   }
 
   @Test
   void 正常系_受講生詳細を更新すると成功メッセージが返ること() throws Exception {
     int id = 1;
+    // URLのIDとボディのstudent.idを合わせるため、ここでセットすると分かりやすい
     Student student = new Student();
+    student.setId(id);
     student.setName("更新太郎");
     student.setKanaName("更新タロウ");
     student.setAge(25);
     student.setEmail("update@example.com");
     student.setRegion("Osaka");
     student.setGender(Gender.MALE);
+
     StudentDetail studentDetail = new StudentDetail();
     studentDetail.setStudent(student);
 
-    // voidメソッドなので、doNothing()でモックの挙動を設定
-    doNothing().when(service).updateStudent(any(StudentDetail.class));
+    // updateStudentはvoidメソッド
+    doNothing().when(service).updateStudent(anyInt(), any(StudentDetail.class));
 
     mockMvc.perform(put("/students/{id}", id)
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(studentDetail)))
         .andExpect(status().isOk())
-        .andExpect(content().string("更新太郎さんの受講生情報が更新されました。"));
+        // コントローラーの実装で "学生情報を更新しました" が返る
+        .andExpect(content().string("学生情報を更新しました"));
 
-    verify(service, times(1)).updateStudent(argThat(detail ->
+    verify(service, times(1)).updateStudent(eq(id), argThat(detail ->
         detail.getStudent() != null &&
-            detail.getStudent().getId() != null &&
-            detail.getStudent().getId().intValue() == id &&
+            detail.getStudent().getId() == id &&
             "更新太郎".equals(detail.getStudent().getName())
     ));
   }
@@ -114,9 +113,9 @@ class StudentControllerTest {
   @Test
   void 異常系_受講生登録時にバリデーションエラーが発生するとエラーメッセージが返ること()
       throws Exception {
-    // 必須項目が不足している不正なデータを作成（例：nameやkanaNameが未設定）
+    // 必須項目が不足している不正なデータ
     Student student = new Student();
-    // student.setName(null);  // ※nullや空文字の場合、@NotNullの制約でエラーとなる前提
+    // student.setName(null); // バリデーション違反を想定
     StudentDetail studentDetail = new StudentDetail();
     studentDetail.setStudent(student);
 
@@ -127,20 +126,18 @@ class StudentControllerTest {
         .andExpect(jsonPath("$.error").value("バリデーションエラー"))
         .andExpect(jsonPath("$.fieldErrors").exists());
 
-    // バリデーションエラーの場合、サービス層は呼ばれない
     verify(service, times(0)).registerStudent(any(StudentDetail.class));
   }
 
   @Test
   void 異常系_不正なIDで受講生詳細を取得するとバリデーションエラーが発生すること()
       throws Exception {
-    int invalidId = 0;  // @Min(1) に違反する値
+    int invalidId = 0; // @Min(1) 違反
     mockMvc.perform(get("/students/{id}", invalidId))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.error").value("バリデーションエラー"))
         .andExpect(jsonPath("$.fieldErrors").exists());
 
-    // バリデーションエラーの場合、サービス層は呼ばれない
     verify(service, times(0)).getStudentDetailById(anyInt());
   }
 
@@ -148,8 +145,9 @@ class StudentControllerTest {
   void 異常系_受講生詳細を更新する際にバリデーションエラーが発生するとエラーメッセージが返ること()
       throws Exception {
     int id = 1;
-    // 不正な更新データ（必須項目が不足）
+    // 不正な更新データ
     Student student = new Student();
+    // student.setName(null); // バリデーション違反を想定
     StudentDetail studentDetail = new StudentDetail();
     studentDetail.setStudent(student);
 
@@ -160,15 +158,15 @@ class StudentControllerTest {
         .andExpect(jsonPath("$.error").value("バリデーションエラー"))
         .andExpect(jsonPath("$.fieldErrors").exists());
 
-    verify(service, times(0)).updateStudent(any(StudentDetail.class));
+    verify(service, times(0)).updateStudent(anyInt(), any(StudentDetail.class));
   }
 
   @Test
   void 異常系_存在しない受講生IDを検索するとCustomAppExceptionが発生しエラーレスポンスが返ること()
       throws Exception {
-    int id = 999; // 存在しないIDなど
-    when(service.getStudentDetailById(id))
-        .thenThrow(new CustomAppException("学生情報が見つかりません。"));
+    int id = 999;
+    when(service.getStudentDetailById(id)).thenThrow(
+        new CustomAppException("学生情報が見つかりません。"));
 
     mockMvc.perform(get("/students/{id}", id))
         .andExpect(status().isNotFound())

--- a/src/test/java/raisetech/StudentManagementSystem/repository/StudentRepositoryTest.java
+++ b/src/test/java/raisetech/StudentManagementSystem/repository/StudentRepositoryTest.java
@@ -2,11 +2,13 @@ package raisetech.StudentManagementSystem.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import raisetech.StudentManagementSystem.data.Student;
+import raisetech.StudentManagementSystem.data.StudentsCourses;
 import raisetech.StudentManagementSystem.domain.Gender;
 
 @MybatisTest
@@ -43,7 +45,7 @@ public class StudentRepositoryTest {
     // 初期の5件に加え、新規登録が成功して 6 件になるはず
     assertThat(actual.size()).isEqualTo(6);
 
-    // さらに、登録した学生が正しく保存されているか確認
+    // 登録した学生が正しく保存されているか確認
     Student inserted = sut.findById(student.getId());
     assertThat(inserted).isNotNull();
     assertThat(inserted.getName()).isEqualTo("新規 学生");
@@ -60,5 +62,27 @@ public class StudentRepositoryTest {
 
     Student updated = sut.findById(1);
     assertThat(updated.getName()).isEqualTo("更新された名前");
+  }
+
+  @Test
+  void コースが追加できること() {
+    // 既存の学生（ID=1）の存在を確認
+    Student student = sut.findById(1);
+    assertThat(student).isNotNull();
+
+    // 新規コース情報を作成
+    StudentsCourses course = new StudentsCourses();
+    course.setStudentId(student.getId());
+    course.setCourseName("Test Course");
+    course.setStartDateAt(LocalDate.of(2025, 1, 1));
+    course.setEndDateAt(LocalDate.of(2025, 12, 31));
+
+    // コースを追加
+    sut.insertStudentsCourses(course);
+
+    // 追加後、学生に紐づくコース情報を取得し、追加されたコースが存在するか検証
+    List<StudentsCourses> courses = sut.findCoursesByStudentId(student.getId());
+    boolean found = courses.stream().anyMatch(c -> "Test Course".equals(c.getCourseName()));
+    assertThat(found).isTrue();
   }
 }

--- a/src/test/java/raisetech/StudentManagementSystem/repository/StudentRepositoryTest.java
+++ b/src/test/java/raisetech/StudentManagementSystem/repository/StudentRepositoryTest.java
@@ -26,7 +26,7 @@ public class StudentRepositoryTest {
 
   @Test
   void 受講生の登録が行えること() {
-    // 新規の学生データを作成（既存のデータと重複しないように名前・メールなどを変更）
+    // 新規の学生データを作成（既存のデータと重複しないようにする）
     Student student = new Student();
     student.setId(null); // AUTO_INCREMENT に任せるため null
     student.setName("新規 学生");
@@ -52,16 +52,34 @@ public class StudentRepositoryTest {
   }
 
   @Test
-  void 受講生の更新が行えること() {
-    // 既存の学生データ（ID=1 のデータ）を取得して更新
+  void 学生基本情報が更新できること() {
+    // 既存の学生（ID=1）を取得して更新
     Student student = sut.findById(1);
     assertThat(student).isNotNull();
 
     student.setName("更新された名前");
-    sut.updateStudent(student);
+    sut.updateStudent(student); // ここは updateStudentBasicInfo が内部で呼ばれる前提
 
     Student updated = sut.findById(1);
     assertThat(updated.getName()).isEqualTo("更新された名前");
+  }
+
+  @Test
+  void 受講コース情報が更新できること() {
+    // 既存の学生（ID=1）の受講コース情報を取得
+    List<StudentsCourses> courses = sut.findCoursesByStudentId(1);
+    assertThat(courses).isNotEmpty();
+    // 更新対象として最初のコースを取得
+    StudentsCourses course = courses.get(0);
+    String originalCourseName = course.getCourseName();
+
+    course.setCourseName(originalCourseName + " Updated");
+
+    // updateStudentsCoursesを使って更新
+    sut.updateStudentsCourses(course);
+
+    StudentsCourses updated = sut.findCourseById(course.getId());
+    assertThat(updated.getCourseName()).isEqualTo(originalCourseName + " Updated");
   }
 
   @Test
@@ -81,8 +99,8 @@ public class StudentRepositoryTest {
     sut.insertStudentsCourses(course);
 
     // 追加後、学生に紐づくコース情報を取得し、追加されたコースが存在するか検証
-    List<StudentsCourses> courses = sut.findCoursesByStudentId(student.getId());
-    boolean found = courses.stream().anyMatch(c -> "Test Course".equals(c.getCourseName()));
+    List<StudentsCourses> updatedCourses = sut.findCoursesByStudentId(student.getId());
+    boolean found = updatedCourses.stream().anyMatch(c -> "Test Course".equals(c.getCourseName()));
     assertThat(found).isTrue();
   }
 }

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,13 +1,16 @@
-INSERT INTO students ( name, kana_name, nickname, age, email, region, remark, gender, is_deleted) VALUES
+-- 学生データの初期登録
+INSERT INTO students (name, kana_name, nickname, age, email, region, remark, gender, is_deleted) VALUES
 ('室伏 広治', 'むろぶし こうじ', 'Koji Murobushi', 78, 'koji.muro@example.com', '川', '削除されました', 'FEMALE', 1),
 ('田中 真美子', 'たなか まみこ', 'まみちゃん', 25, 'tanaka@example.com', '北海道', '生まれ変わりました。', 'FEMALE', 0),
 ('錦織 圭', 'にしこり けい', 'Kei', 34, 'kei.nishikori@example.com', 'アメリカ', 'この学生は優秀です。', 'MALE', 0),
 ('池江 璃花子', 'いけえ りかこ', 'Rika', 24, 'rikako.ikee@example.com', '東京', '将来は海外へ行きたい', 'MALE', 0),
 ('井上 花月', 'いのうえ かづき', 'はなちゃん', 25, 'rikako.inoue@example.com', '北海道', '花嫁', 'FEMALE', 0);
 
-INSERT INTO students_courses (start_date_at, end_date_at, course_name) VALUES
-('2025-03-01', '2025-06-01', '新しいコース'),
-('2025-03-01', NULL, 'マーケティング'),
-('2024-03-01', NULL, 'WordPress'),
-('2024-04-01', NULL, 'マーケティング'),
-('2025-02-01', NULL, 'Java');
+-- コースデータの初期登録
+-- 各コースに対して、対応する student_id を指定
+INSERT INTO students_courses (student_id, start_date_at, end_date_at, course_name) VALUES
+(1, '2025-03-01', '2025-06-01', '新しいコース'),
+(2, '2025-03-01', NULL, 'マーケティング'),
+(3, '2024-03-01', NULL, 'WordPress'),
+(4, '2024-04-01', NULL, 'マーケティング'),
+(5, '2025-02-01', NULL, 'Java');


### PR DESCRIPTION
## 1.updateStudent メソッドの修正
- id をパスパラメータとして受け取り、リクエストボディ内の id と一致するかチェックするように変更
- StudentService 側のメソッドも updateStudent(int id, StudentDetail studentDetail) に変更し、整合性チェックを追加

## 2.新しいコース追加機能 (addCourseForStudent メソッド) の実装
- POST /{id}/courses エンドポイントを追加し、指定した id の学生に新しいコースを追加できるようにした
- サービス層 (StudentService) で、学生の存在確認や最大3コースの制約チェック、未終了コースの判定を追加
- StudentRepository に insertStudentsCourses メソッドを追加し、新しいコースを students_courses テーブルに追加できるようにした

## 3.MyBatis の XML (studentRepository.xml) への insertStudentsCourses クエリ追加
- INSERT INTO students_courses (student_id, course_name, start_date_at, end_date_at) の SQL を定義し、新規コース登録を可能にした

## 動作確認
### 前データベース情報
![前データベース](https://github.com/user-attachments/assets/cee06558-1d9d-45fc-91b3-9e0f43b2f3ab)
- PUT /{id} で学生情報を更新 → id のチェックが正しく動くか
![IDチェック](https://github.com/user-attachments/assets/1985c2ac-5252-49ab-ac35-8369e679f877)

- データベースに新しいコースが正しく追加されるか
![コース追加OK](https://github.com/user-attachments/assets/79f81dc7-353c-44a8-9c3e-634b10500315)

- POST /{id}/courses で新しいコースを追加 →
  - 前のコースが終了していない場合にエラーが出るか
![コース追加エラー](https://github.com/user-attachments/assets/43431af5-c5ac-4932-8802-e2b2ca262459)

  - 3つ以上のコース追加が拒否されるか(データベースでid1の学生が3つ受講し終えたことを確認してからコース追加処理が拒否されたことを確認しました。)
![中間データベース](https://github.com/user-attachments/assets/a92019bc-5d18-4ed0-bc81-c13a5feed1e2)
![コース追加エラー2](https://github.com/user-attachments/assets/3acab029-eb29-4760-a1e2-4500e91878f3)


