### PR TITLE
GitHub ActionsによるJavaアプリのCDパイプライン

### DIFF
--- a/.github/workflows/JavaTest.yml
+++ b/.github/workflows/JavaTest.yml
@@ -21,7 +21,11 @@ jobs:
         distribution: 'temurin'
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+      uses: gradle/actions/setup-gradle@v4
+
+    - name: Create application.properties  # ✅ ここを追加！
+      run: |
+        echo "${{ secrets.APPLICATION_PROPERTIES }}" > src/main/resources/application.properties
 
     - name: Grant execute permission for Gradle Wrapper
       run: chmod +x ./gradlew

--- a/.github/workflows/JavaTest.yml
+++ b/.github/workflows/JavaTest.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   EC2_USER: 'ec2-user'
-  EC2_HOST: '35.72.14.92'
+  EC2_HOST: '54.250.38.218'
   SRC_PATH: 'build/libs/*.jar'
   DEST_PATH: '/home/ec2-user/StudentManagementSystem.jar'
 
@@ -45,6 +45,7 @@ jobs:
         run: |
           echo "$PRIVATE_KEY" > private_key && chmod 600 private_key
           scp -o StrictHostKeyChecking=no -i private_key $SRC_PATH $EC2_USER@$EC2_HOST:$DEST_PATH
+          rm -f private_key
 
       - name: SSH Application Deploy
         uses: appleboy/ssh-action@master
@@ -65,7 +66,7 @@ jobs:
             [Service]
             ExecStart = java -jar ${DEST_PATH}
             EnvironmentFile = /etc/sysconfig/StudentManagement
-            Restart = no
+            Restart = on-failure
             Type = simple
             User = ec2-user
             Group = ec2-user

--- a/.github/workflows/JavaTest.yml
+++ b/.github/workflows/JavaTest.yml
@@ -12,23 +12,23 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up JDK 21
-      uses: actions/setup-java@v4
-      with:
-        java-version: '21'
-        distribution: 'temurin'
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
 
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
-    - name: Create application.properties  # ✅ ここを追加！
-      run: |
-        echo "${{ secrets.APPLICATION_PROPERTIES }}" > src/main/resources/application.properties
+      - name: Create application.properties
+        run: |
+          echo "${{ secrets.APPLICATION_PROPERTIES }}" > src/main/resources/application.properties
 
-    - name: Grant execute permission for Gradle Wrapper
-      run: chmod +x ./gradlew
+      - name: Grant execute permission for Gradle Wrapper
+        run: chmod +x ./gradlew
 
-    - name: Build with Gradle Wrapper
-      run: ./gradlew build
+      - name: Build with Gradle Wrapper
+        run: ./gradlew build

--- a/.github/workflows/JavaTest.yml
+++ b/.github/workflows/JavaTest.yml
@@ -1,0 +1,26 @@
+name: Java CI with Gradle
+
+on:
+  push:
+    branches: [ "release" ]
+  
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+
+    - name: Build with Gradle Wrapper
+      run: ./gradlew build

--- a/.github/workflows/JavaTest.yml
+++ b/.github/workflows/JavaTest.yml
@@ -53,7 +53,7 @@ jobs:
           username: ${{ env.EC2_USER }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
           envs: DEST_PATH
-        script: |
+        command: |
           sudo yum update -y
           if [ -f /etc/systemd/system/StudentManagement.service ]; then
             echo "already exists Service File"

--- a/.github/workflows/JavaTest.yml
+++ b/.github/workflows/JavaTest.yml
@@ -1,15 +1,18 @@
-name: Java CI with Gradle
+name: Java CD with Gradle
 
 on:
   push:
     branches: [ "release" ]
 
-jobs:
-  build:
+env:
+  EC2_USER: 'ec2-user'
+  EC2_HOST: '35.72.14.92'
+  SRC_PATH: 'build/libs/*.jar'
+  DEST_PATH: '/home/ec2-user/StudentManagementSystem.jar'
 
+jobs:
+  deploy:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -30,5 +33,52 @@ jobs:
       - name: Grant execute permission for Gradle Wrapper
         run: chmod +x ./gradlew
 
+      - name: Test with Gradle Wrapper
+        run: ./gradlew test
+
       - name: Build with Gradle Wrapper
-        run: ./gradlew build
+        run: ./gradlew bootJar
+
+      - name: SCP Copy Application to EC2
+        env:
+          PRIVATE_KEY: ${{secrets.AWS_EC2_PRIVATE_KEY}}
+        run: |
+          echo "$PRIVATE_KEY" > private_key && chmod 600 private_key
+          scp -o StrictHostKeyChecking=no -i private_key $SRC_PATH $EC2_USER@$EC2_HOST:$DEST_PATH
+
+      - name: SSH Application Deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ env.EC2_HOST }}
+          username: ${{ env.EC2_USER }}
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          envs: DEST_PATH
+        script: |
+          sudo yum update -y
+          if [ -f /etc/systemd/system/StudentManagement.service ]; then
+            echo "already exists Service File"
+          else
+            cat <<EOL | sudo tee -a /etc/systemd/system/StudentManagement.service
+          [Unit]
+          Description = StudentManagement App
+
+          [Service]
+          ExecStart = java -jar ${DEST_PATH}
+          EnvironmentFile = /etc/sysconfig/StudentManagement
+          Restart = no
+          Type = simple
+          User = ec2-user
+          Group = ec2-user
+          SuccessExitStatus = 143
+
+          [Install]
+          WantedBy = multi-user.target
+          EOL
+          fi
+
+          sudo systemctl daemon-reload
+          if sudo systemctl status StudentManagement 2>&1 | grep "Active: active (running)" ; then
+            sudo systemctl restart StudentManagement
+          else
+            sudo systemctl start StudentManagement
+          fi

--- a/.github/workflows/JavaTest.yml
+++ b/.github/workflows/JavaTest.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           host: ${{ env.EC2_HOST }}
           username: ${{ env.EC2_USER }}
-          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          key: ${{ secrets.AWS_EC2_PRIVATE_KEY }}
           envs: DEST_PATH
           script: |
             sudo yum update -y

--- a/.github/workflows/JavaTest.yml
+++ b/.github/workflows/JavaTest.yml
@@ -3,7 +3,7 @@ name: Java CI with Gradle
 on:
   push:
     branches: [ "release" ]
-  
+
 jobs:
   build:
 
@@ -13,6 +13,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
@@ -21,6 +22,9 @@ jobs:
 
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+
+    - name: Grant execute permission for Gradle Wrapper
+      run: chmod +x ./gradlew
 
     - name: Build with Gradle Wrapper
       run: ./gradlew build

--- a/.github/workflows/JavaTest.yml
+++ b/.github/workflows/JavaTest.yml
@@ -53,32 +53,32 @@ jobs:
           username: ${{ env.EC2_USER }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
           envs: DEST_PATH
-        command: |
-          sudo yum update -y
-          if [ -f /etc/systemd/system/StudentManagement.service ]; then
-            echo "already exists Service File"
-          else
-            cat <<EOL | sudo tee -a /etc/systemd/system/StudentManagement.service
-          [Unit]
-          Description = StudentManagement App
+          script: |
+            sudo yum update -y
+            if [ -f /etc/systemd/system/StudentManagement.service ]; then
+              echo "already exists Service File"
+            else
+              cat <<EOL | sudo tee /etc/systemd/system/StudentManagement.service
+            [Unit]
+            Description = StudentManagement App
 
-          [Service]
-          ExecStart = java -jar ${DEST_PATH}
-          EnvironmentFile = /etc/sysconfig/StudentManagement
-          Restart = no
-          Type = simple
-          User = ec2-user
-          Group = ec2-user
-          SuccessExitStatus = 143
+            [Service]
+            ExecStart = java -jar ${DEST_PATH}
+            EnvironmentFile = /etc/sysconfig/StudentManagement
+            Restart = no
+            Type = simple
+            User = ec2-user
+            Group = ec2-user
+            SuccessExitStatus = 143
 
-          [Install]
-          WantedBy = multi-user.target
-          EOL
-          fi
+            [Install]
+            WantedBy = multi-user.target
+            EOL
+            fi
 
-          sudo systemctl daemon-reload
-          if sudo systemctl status StudentManagement 2>&1 | grep "Active: active (running)" ; then
-            sudo systemctl restart StudentManagement
-          else
-            sudo systemctl start StudentManagement
-          fi
+            sudo systemctl daemon-reload
+            if sudo systemctl status StudentManagement 2>&1 | grep "Active: active (running)" ; then
+              sudo systemctl restart StudentManagement
+            else
+              sudo systemctl start StudentManagement
+            fi


### PR DESCRIPTION
## 概要
この変更では、GitHub Actions を使用して Java アプリケーションの継続的デプロイ（CD）を自動化しました。release ブランチに push すると、以下の処理が自動で実行されます。

## 変更内容
### 1.GitHub Actions のワークフローファイル JavaTest.yml を新規追加
- release ブランチへの push をトリガーに CI/CD パイプラインが実行されるよう設定しました。

### 2.Gradle を使用したビルド & テスト
- JDK 21（Temurin）をセットアップ
- Gradle のセットアップと権限設定
- application.properties を GitHub Secrets から作成
- ./gradlew test でテストを実行
- ./gradlew bootJar で Spring Boot アプリをビルド

### 3.EC2 へのデプロイ
- SCP（Secure Copy）で build/libs/*.jar を EC2 インスタンスに転送
- appleboy/ssh-action を使用して EC2 に SSH 接続し、以下の処理を実行：
  - yum update -y で OS のパッケージを更新
  - Systemd サービスファイル /etc/systemd/system/StudentManagement.service の作成
  - systemctl daemon-reload で設定を再読み込み
  - 既存のアプリが稼働中なら systemctl restart、稼働していなければ systemctl start
 
## GitHub Actions での CD 成功を確認しました
![スクリーンショット 2025-04-03 170107](https://github.com/user-attachments/assets/2154828a-a516-4df3-a517-740984dfacfb)
